### PR TITLE
Override margins on pre tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -219,6 +219,8 @@ add_action('wp_enqueue_scripts', function() {
 
 == Changelog ==
 
+- Fix: Zeros out margins on pre elements for better theme compatability
+
 = 1.2.1 - 2022-08-27 =
 - Fix: Remove nested pre tags (changed to div) in editor
 - Feature: Added test coverage with cypress

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -4,8 +4,7 @@
     @apply relative;
 }
 .wp-block-kevinbatdorf-code-block-pro pre {
-    overflow-wrap: break-word;
-    @apply overflow-auto p-6 text-inherit;
+    @apply overflow-auto p-6 text-inherit m-0;
 }
 .wp-block-kevinbatdorf-code-block-pro pre code {
     @apply m-0 p-0 bg-transparent text-inherit;


### PR DESCRIPTION
This PR sets margins to 0 on pre tags to avoid inheriting it from the user agent. 