### PR TITLE
Add prismatic compatibility overrides

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -19,7 +19,7 @@ add_action('init', function () {
 });
 add_action('admin_init', function () {
     wp_add_inline_script('kevinbatdorf-code-block-pro-editor-script', 'window.codeBlockPro = ' . wp_json_encode([
-    'pluginUrl' => esc_url_raw(plugin_dir_url(__FILE__)),
+        'pluginUrl' => esc_url_raw(plugin_dir_url(__FILE__)),
     ]) . ';');
 });
 

--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -19,6 +19,8 @@ add_action('init', function () {
 });
 add_action('admin_init', function () {
     wp_add_inline_script('kevinbatdorf-code-block-pro-editor-script', 'window.codeBlockPro = ' . wp_json_encode([
-        'pluginUrl' => esc_url_raw(plugin_dir_url(__FILE__)),
+    'pluginUrl' => esc_url_raw(plugin_dir_url(__FILE__)),
     ]) . ';');
 });
+
+include_once(__DIR__ . '/compatibility.php');

--- a/compatibility.php
+++ b/compatibility.php
@@ -1,0 +1,17 @@
+<?php
+
+defined( 'ABSPATH' ) or die;
+
+/**
+ * Prismatic override - https://wordpress.org/plugins/prismatic/
+ * This plugin encodes all <code> tags in the content, resulting in escaped html.
+ * https://plugins.trac.wordpress.org/browser/prismatic/trunk/inc/prismatic-core.php#L59
+ * Will monitor that plugin periodically and remove this override if it is updated.
+ */
+class Prismatic {
+    static function options_general() {}
+    static function options_prism() {}
+    static function options_highlight() {}
+    static function options_plain() {}
+}
+function prismatic() {}

--- a/readme.txt
+++ b/readme.txt
@@ -224,6 +224,8 @@ It's possible you have the Prismatic plugin installed. Currently I don't have a 
 
 == Changelog ==
 
+- Compatability: Disable Prismatic. They use an encoding function on all code indescriminately.
+
 = 1.2.7 - 2022-08-31 =
 - Fix: Add style overrides for the Hueman theme (and generally good overrides)
 

--- a/readme.txt
+++ b/readme.txt
@@ -213,10 +213,6 @@ add_action('wp_enqueue_scripts', function() {
 });
 `
 
-= I'm seeing the html output instead of the styled code =
-
-It's possible you have the Prismatic plugin installed. Currently I don't have a workaround set up to support both plugins, so you'll have to deactive Prismatic while evaluating which plugin to use.
-
 == Screenshots ==
 
 1. Quickly swap over themes in the editor


### PR DESCRIPTION
Prismatic: https://wordpress.org/plugins/prismatic/

This plugin encodes all `<code>` tags in the content, resulting in escaped html.

https://plugins.trac.wordpress.org/browser/prismatic/trunk/inc/prismatic-core.php#L59

I'll monitor that plugin periodically and remove this override if it is updated.

With Prismatic active:

![Screen Shot 2022-08-31 at 9 53 36 PM](https://user-images.githubusercontent.com/1478421/187815608-57c89c40-30ac-429f-be46-d158babe17b7.png)

Original: 

![Screen Shot 2022-08-31 at 9 53 31 PM](https://user-images.githubusercontent.com/1478421/187815583-2c9e6c0c-c3df-4544-aa02-8b177045f02e.png)
