### PR TITLE
Add compatibility fix and test for prismatic

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,8 +3,8 @@ on:
     push:
     workflow_dispatch:
     schedule:
-    # At 08:00 on Thursday.
-    - cron: "0 8 * * 4"
+    # At 08:00 daily
+    - cron: "0 8 * * *"
 jobs:
     test:
         name: Cypress

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,10 +23,10 @@ jobs:
               if: ${{ matrix.wp-version }}
               run: rm .wp-env.json
             - name: Maybe change WP version
-              uses: devops-actions/json-to-file@v1.0.0
+              uses: jsdaniell/create-json@v1.2.1
               if: ${{ matrix.wp-version }}
               with:
-                  filename: '.wp-env.json'
+                  name: '.wp-env.json'
                   json: '{
                     "core": ${{ matrix.wp-version }},
                     "plugins":["."],

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,7 +33,7 @@ jobs:
                     }
                   }'
             - name: Start server
-              run: wp-env start
+              run: wp-env start --update
             - name: Cypress run
               uses: cypress-io/github-action@v4
               with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,14 +19,14 @@ jobs:
               run: |
                   npm ci
                   npm run build
-            - name: Maybe remove wp-env
+            - name: Maybe remove .wp-env.json
               if: ${{ matrix.wp-version }}
               run: rm .wp-env.json
-            - name: Change WP version
+            - name: Maybe change WP version
               uses: devops-actions/json-to-file@v1.0.0
               if: ${{ matrix.wp-version }}
               with:
-                  filename: 'wp-env.json'
+                  filename: '.wp-env.json'
                   json: '{
                     "core": ${{ matrix.wp-version }},
                     "plugins":["."],

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,6 +23,7 @@ jobs:
                   rm .wp-env.json
             - name: Change WP version
               uses: devops-actions/json-to-file@v1.0.0
+              if: ${{ matrix.wp-version }}
               with:
                   filename: 'wp-env.json'
                   json: '{

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,7 +18,6 @@ jobs:
             - name: Install server
               run: |
                   npm ci
-                  npm install -g @wordpress/env
                   npm run build
                   rm .wp-env.json
             - name: Change WP version
@@ -34,7 +33,9 @@ jobs:
                     }
                   }'
             - name: Start server
-              run: wp-env start --update
+              run: |
+                  npm install -g @wordpress/env
+                  wp-env start --update
             - name: Cypress run
               uses: cypress-io/github-action@v4
               with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,7 +25,13 @@ jobs:
               uses: jsdaniell/create-json@v1.2.1
               with:
                   name: 'wp-env.json'
-                  json: '{"core": ${{ matrix.wp-version }},"plugins":["."]}'
+                  json: '{
+                    "core": ${{ matrix.wp-version }},
+                    "plugins":["."],
+                    "mappings": {
+                      "wp-content/plugins/prismatic": "https://downloads.wordpress.org/plugin/prismatic.zip"
+                    }
+                  }'
             - name: Start server
               run: wp-env start
             - name: Cypress run

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,7 +19,9 @@ jobs:
               run: |
                   npm ci
                   npm run build
-                  rm .wp-env.json
+            - name: Maybe remove wp-env
+              if: ${{ matrix.wp-version }}
+              run: rm .wp-env.json
             - name: Change WP version
               uses: devops-actions/json-to-file@v1.0.0
               if: ${{ matrix.wp-version }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,9 +22,9 @@ jobs:
                   npm run build
                   rm .wp-env.json
             - name: Change WP version
-              uses: jsdaniell/create-json@v1.2.1
+              uses: devops-actions/json-to-file@v1.0.0
               with:
-                  name: 'wp-env.json'
+                  filename: 'wp-env.json'
                   json: '{
                     "core": ${{ matrix.wp-version }},
                     "plugins":["."],
@@ -40,12 +40,12 @@ jobs:
                 browser: chrome
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v3
               if: failure()
               with:
                   name: cypress-screenshots
                   path: cypress/screenshots
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v3
               if: failure()
               with:
                   name: cypress-videos

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,7 @@
 {
     "core": null,
-    "plugins": ["."]
+    "plugins": [
+        ".",
+        "https://downloads.wordpress.org/plugin/prismatic.zip"
+    ]
 }

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
     "core": null,
-    "plugins": [
-        ".",
-        "https://downloads.wordpress.org/plugin/prismatic.zip"
-    ]
+    "plugins": ["."],
+    "mappings": {
+        "wp-content/plugins/prismatic": "https://downloads.wordpress.org/plugin/prismatic.zip"
+    }
 }

--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -4,7 +4,7 @@
  * Description:       Code highlighting powered by the VS Code engine
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.9.1
+ * Version:           1.9.2
  * Author:            Kevin Batdorf
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/cypress/e2e/compatability.cy.js
+++ b/cypress/e2e/compatability.cy.js
@@ -1,0 +1,18 @@
+context('Compatability checks', () => {
+    before(() => {
+        cy.loginUser();
+    });
+    after(() => {
+        // make sure we can uninstall prismatic
+        cy.uninstallPlugin('prismatic');
+        cy.logoutUser();
+    });
+    it('Installs alongside Prismatic with no errors', () => {
+        cy.installPlugin('prismatic');
+        // make sure we don't see thhe word fatal or error
+        cy.get('body').should('not.contain', 'fatal error');
+        // make sure both prismatic and code-block-pro are active
+        cy.get('#deactivate-code-block-pro').should('exist');
+        cy.get('#deactivate-prismatic').should('exist');
+    });
+});

--- a/cypress/e2e/language.cy.js
+++ b/cypress/e2e/language.cy.js
@@ -1,11 +1,19 @@
 // Check support/globals.js for some default checks
 // as well as start up and clean up methods
+before(() => {
+    cy.loginUser();
+});
 beforeEach(() => {
+    cy.visitNewPageEditor();
     cy.addBlock('code-block-pro');
     cy.getPostContent('.wp-block[class$="code-block-pro"]').should('exist');
 
     cy.focusBlock('code-block-pro', 'textarea');
     cy.get('.wp-block[class$="code-block-pro"] textarea').should('have.focus');
+});
+after(() => {
+    cy.saveDraft(); // so we can leave without an alert
+    cy.logoutUser();
 });
 context('Language checks', () => {
     it('Renders properly when switching languages', () => {

--- a/cypress/e2e/themes.cy.js
+++ b/cypress/e2e/themes.cy.js
@@ -1,11 +1,19 @@
 // Check support/globals.js for some default checks
 // as well as start up and clean up methods
+before(() => {
+    cy.loginUser();
+});
 beforeEach(() => {
+    cy.visitNewPageEditor();
     cy.addBlock('code-block-pro');
     cy.getPostContent('.wp-block[class$="code-block-pro"]').should('exist');
 
     cy.focusBlock('code-block-pro', 'textarea');
     cy.get('.wp-block[class$="code-block-pro"] textarea').should('have.focus');
+});
+after(() => {
+    cy.saveDraft(); // so we can leave without an alert
+    cy.logoutUser();
 });
 context('Theme checks', () => {
     it('Renders properly when switching themes', () => {

--- a/cypress/support/globals.js
+++ b/cypress/support/globals.js
@@ -12,14 +12,3 @@ afterEach(() => {
         expect(win.console.error).to.have.callCount(0);
     });
 });
-
-beforeEach(() => {
-    cy.loginUser();
-    cy.visitNewPageEditor();
-});
-
-afterEach(() => {
-    cy.saveDraft(); // so we can leave without an alert
-    // cy.uninstallPlugin('rust-starter')
-    cy.logoutUser();
-});

--- a/php/compatibility.php
+++ b/php/compatibility.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) or die;
+defined('ABSPATH') or die;
 
 /**
  * Prismatic override - https://wordpress.org/plugins/prismatic/
@@ -9,11 +9,25 @@ defined( 'ABSPATH' ) or die;
  * Will monitor that plugin periodically and remove this override if it is updated.
  */
 if (!class_exists('Prismatic')) {
-    class Prismatic {
-        static function options_general() {}
-        static function options_prism() {}
-        static function options_highlight() {}
-        static function options_plain() {}
+    class Prismatic
+    {
+        public static function options_general()
+        {
+        }
+        public static function options_advanced()
+        {
+        }
+        public static function options_prism()
+        {
+        }
+        public static function options_highlight()
+        {
+        }
+        public static function options_plain()
+        {
+        }
     }
-    function prismatic() {}
+    function prismatic()
+    {
+    }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82
 Tags:              block, code, syntax, snippet, highlighter, JavaScript, php, vs code, torchlight, shiki
 Tested up to:      6.1
-Stable tag:        1.9.1
+Stable tag:        1.9.2
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -242,6 +242,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 4. Use highlighting and blur to focus on parts of the code.
 
 == Changelog ==
+
+= 1.9.2 - 2022-11-22 =
+- Compatibility: Adds a method override to allow users to activate when prismatic is installed.
 
 = 1.9.1 - 2022-11-21 =
 - Fix: Fixed a situations where the highlighter was miscalculating its width


### PR DESCRIPTION
This fixes an issue with prismatic. Unfortunately I need to disable their plugin in order to function as they indiscriminately filter all code tags. I do this in a way that is not destructive in case the user later deletes this plugin. However, if they add a new method, I need to override that one too.

This PR will override a new method they added, and also includes a test to check daily for fatal errors via GitHu, using cypress

more context: https://wordpress.org/support/topic/enabling-plugin-with-prismatic-gives-error/