### PR TITLE
Remove outline from block

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -243,6 +243,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Fix: Removes inner focus outline from Gutenberg update
+
 = 1.9.3 - 2022-12-05 =
 - Fix: Adjusted editor padding for line numbers to better match the front end
 - Fix: Removed the TW border default in the editor as it was overriding some wp defaults

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -32,7 +32,7 @@
 }
 .code-block-pro-editor textarea,
 .code-block-pro-editor pre {
-    @apply m-0 text-left;
+    @apply m-0 text-left focus:outline-none;
     direction: ltr !important;
 }
 .code-block-pro-editor.cbp-has-line-numbers pre {


### PR DESCRIPTION
Latest Gutenberg plugin adds a blue outline on inner textarea elements when focused. This doesn't work for us since it's acting like a code editor.