### PR TITLE
Add smarter load listener

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -243,14 +243,17 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Tweak: Load scripts (copy button, highlight) on multiple lifecycle points
+- Tweak: Make the above scripts idempotent so they can run multiple times
+
 = 1.9.3 - 2022-12-05 =
 - Fix: Adjusted editor padding for line numbers to better match the front end
 - Fix: Removed the TW border default in the editor as it was overriding some wp defaults
 - Fix: Updated a typo on the word "focus"
-- Testing: Adds coverage for every main feature.
+- Testing: Adds coverage for every main feature
 
 = 1.9.2 - 2022-11-22 =
-- Compatibility: Adds a method override to allow users to activate when prismatic is installed.
+- Compatibility: Adds a method override to allow users to activate when prismatic is installed
 
 = 1.9.1 - 2022-11-21 =
 - Fix: Fixed a situations where the highlighter was miscalculating its width

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -1,11 +1,13 @@
 import copy from 'copy-to-clipboard';
 
-// Handle copy button
-addEventListener('DOMContentLoaded', () => {
+const handleCopyButton = () => {
     const buttons = Array.from(
-        document.querySelectorAll('.code-block-pro-copy-button'),
+        document.querySelectorAll(
+            '.code-block-pro-copy-button:not(.cbp-cb-loaded)',
+        ),
     );
     buttons.forEach((button) => {
+        button.classList.add('cbp-cb-loaded');
         // Setting it to block here lets users deactivate the plugin safely
         button.style.display = 'block';
         button.addEventListener('click', (event) => {
@@ -19,16 +21,18 @@ addEventListener('DOMContentLoaded', () => {
             }, 2000);
         });
     });
-});
+};
 
-// Handle highlighter
-addEventListener('DOMContentLoaded', () => {
+const handleHighlighter = () => {
     const codeBlocks = Array.from(
-        document.querySelectorAll('.wp-block-kevinbatdorf-code-block-pro pre'),
+        document.querySelectorAll(
+            '.wp-block-kevinbatdorf-code-block-pro pre:not(.cbp-hl-loaded)',
+        ),
     );
 
     codeBlocks.forEach((codeBlock) => {
-        // search for highlights
+        codeBlock.classList.add('cbp-hl-loaded');
+        // Search for highlights
         const highlighters = codeBlock.querySelectorAll('.cbp-line-highlight');
         if (!highlighters.length) return;
 
@@ -60,18 +64,18 @@ addEventListener('DOMContentLoaded', () => {
             );
         });
     });
-});
+};
 
-// Handle font loading
-addEventListener('DOMContentLoaded', () => {
+const handleFontLoading = () => {
     if (!window.codeBlockPro?.pluginUrl) return;
+    const elements = Array.from(
+        document.querySelectorAll(
+            '[data-code-block-pro-font-family]:not(.cbp-ff-loaded)',
+        ) || [],
+    );
+    elements.forEach((e) => e.classList.add('cbp-ff-loaded'));
     const fontsToLoad = new Set(
-        Array.from(
-            document.querySelectorAll('[data-code-block-pro-font-family]') ??
-                [],
-        )
-            .map((f) => f.dataset.codeBlockProFontFamily)
-            .filter(Boolean),
+        elements.map((f) => f.dataset.codeBlockProFontFamily).filter(Boolean),
     );
     [...fontsToLoad].forEach(async (fontName) => {
         const font = new FontFace(
@@ -81,4 +85,15 @@ addEventListener('DOMContentLoaded', () => {
         await font.load();
         document.fonts.add(font);
     });
-});
+};
+
+const runAll = () => {
+    handleCopyButton();
+    handleHighlighter();
+    handleFontLoading();
+};
+
+// Functions are idempotent, so we can run them on load and DOMContentLoaded
+runAll();
+window.addEventListener('DOMContentLoaded', runAll);
+window.addEventListener('load', runAll);


### PR DESCRIPTION
This will load the front end scripts (highlighting, copy button, font loading) immediately, during `DOMContentLoaded`, and `load` so that no matter where the user (more likely a plugin) loads the script it should run.

Tested this using Autoptimize and various configurations