### PR TITLE
Add footer text start

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -243,6 +243,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Feature: Add footer with left aligned text
+
 = 1.9.3 - 2022-12-05 =
 - Fix: Adjusted editor padding for line numbers to better match the front end
 - Fix: Removed the TW border default in the editor as it was overriding some wp defaults

--- a/src/editor/components/FooterSelect.tsx
+++ b/src/editor/components/FooterSelect.tsx
@@ -2,6 +2,7 @@ import { BaseControl } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Attributes } from '../../types';
 import { SimpleStringEnd } from './footers/SimpleStringEnd';
+import { SimpleStringStart } from './footers/SimpleStringStart';
 
 type FooterSelectProps = {
     attributes: Attributes;
@@ -14,6 +15,7 @@ export const FooterSelect = ({ attributes, onClick }: FooterSelectProps) => {
     const types = {
         none: __('None', 'code-block-pro'),
         simpleStringEnd: __('Simple string end', 'code-block-pro'),
+        simpleStringStart: __('Simple string start', 'code-block-pro'),
     };
 
     return (
@@ -30,7 +32,7 @@ export const FooterSelect = ({ attributes, onClick }: FooterSelectProps) => {
                             : type
                     }
                     help={
-                        ['simpleStringEnd'].includes(slug)
+                        ['simpleStringEnd', 'SimpleStringStart'].includes(slug)
                             ? __('Update text in Settings', 'code-block-pro')
                             : undefined
                     }
@@ -61,6 +63,9 @@ export const FooterType = (attributes: Partial<Attributes>) => {
     const { footerType } = attributes;
     if (footerType === 'simpleStringEnd') {
         return <SimpleStringEnd {...attributes} />;
+    }
+    if (footerType === 'simpleStringStart') {
+        return <SimpleStringStart {...attributes} />;
     }
     return null;
 };

--- a/src/editor/components/footers/SimpleStringStart.tsx
+++ b/src/editor/components/footers/SimpleStringStart.tsx
@@ -1,0 +1,83 @@
+import { colord, AnyColor } from 'colord';
+import { Lang } from 'shiki';
+import { Attributes } from '../../../types';
+import { languages } from '../../../util/languages';
+
+export const SimpleStringStart = ({
+    language,
+    bgColor,
+    textColor,
+    footerString,
+    footerLink,
+    footerLinkTarget,
+    disablePadding,
+}: Partial<Attributes>) => {
+    const bgC = colord(bgColor as AnyColor);
+    const textC = colord(textColor as AnyColor);
+    const text = textC.isDark() ? textC.lighten(0.05) : textC.darken(0.05);
+    return (
+        <span
+            style={{
+                display: 'flex',
+                alignItems: 'flex-end',
+                padding: disablePadding ? '10px 0 0 0' : '10px 10px 10px 16px',
+                width: '100%',
+                justifyContent: 'flex-start',
+                backgroundColor: bgC.toHex(),
+                color: text.toHex(),
+                fontSize: '12px',
+                lineHeight: '1',
+                position: 'relative',
+            }}>
+            <Inner
+                text={footerString || languages[language as Lang]}
+                color={text.toHex()}
+                link={footerLink}
+                linkTarget={footerLinkTarget}
+            />
+        </span>
+    );
+};
+
+const Inner = ({
+    text,
+    color,
+    link,
+    linkTarget,
+}: {
+    text?: string;
+    color: string;
+    link?: string;
+    linkTarget?: boolean;
+}) => {
+    if (!link) return <>{text}</>;
+    const style = {
+        color,
+        // attempt to reset the link to not inheret from theme
+        textDecoration: 'none',
+        fontWeight: 'normal',
+        border: 'none',
+        background: 'none',
+        borderRadius: '0',
+        padding: '0',
+        margin: '0',
+    };
+    if (linkTarget) {
+        return (
+            <a
+                className="cbp-footer-link"
+                href={link}
+                style={style}
+                target={'_blank'}
+                // Gutenberg required
+                rel={'noopener noreferrer'}>
+                {text}
+            </a>
+        );
+    }
+    return (
+        <a className="cbp-footer-link" href={link} style={style}>
+            {text}
+        </a>
+    );
+};

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -37,10 +37,12 @@ export const SidebarControls = ({
     const { setPreviousSettings } = useGlobalStore();
     const { headerType, footerType } = attributes;
 
+    const footersNeedingLinks = ['simpleStringEnd', 'simpleStringStart'];
+
     const showHeaderTextEdit = ['simpleString'].includes(headerType);
-    const showFooterTextEdit = ['simpleStringEnd'].includes(footerType);
-    const showFooterLinkEdit = ['simpleStringEnd'].includes(footerType);
-    const showFooterLinkTargetEdit = ['simpleStringEnd'].includes(footerType);
+    const showFooterTextEdit = footersNeedingLinks.includes(footerType);
+    const showFooterLinkEdit = footersNeedingLinks.includes(footerType);
+    const showFooterLinkTargetEdit = footersNeedingLinks.includes(footerType);
 
     return (
         <InspectorControls>


### PR DESCRIPTION
This adds a footer option to align next on the left. Notice the text here:

![Screen Shot 2022-12-21 at 7 06 18 PM](https://user-images.githubusercontent.com/1478421/209027895-78558b68-4154-4fef-80d3-c74526fb90f0.png)

It essentially copies the right-side footer text option but places the text at 16px from the left vs 10px on the right