### PR TITLE
Fix line wrap editor bug

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,7 @@
     },
     "ignorePatterns": ["node_modules/", "pkg/", "build/"],
     "parser": "@typescript-eslint/parser",
-    "plugins": [],
+    "plugins": ["no-only-tests"],
     "rules": {
         "require-await": "error",
         "quotes": ["error", "single", { "avoidEscape": true }],
@@ -33,6 +33,7 @@
         "semi": ["error", "always"],
         "space-in-parens": ["error", "never"],
         "key-spacing": ["error", { "afterColon": true }],
+        "no-only-tests/no-only-tests": "warn",
         "space-infix-ops": ["error"],
         "space-before-function-paren": [
             "error",

--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -13,6 +13,7 @@ jobs:
             - name: npm install and build
               run: |
                   npm ci
+                  npx eslint --max-warnings 0 .
                   npm run build
               env:
                   CI: true

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,6 +21,7 @@ jobs:
             - name: Install server
               run: |
                   npm ci
+                  npx eslint --max-warnings 0 .
                   npm run build
             - name: Maybe remove .wp-env.json
               if: ${{ matrix.wp-version }}

--- a/.github/workflows/release-to-wp-org.yml
+++ b/.github/workflows/release-to-wp-org.yml
@@ -13,6 +13,7 @@ jobs:
             - name: npm install and build
               run: |
                   npm ci
+                  npx eslint --max-warnings 0 .
                   npm run build
               env:
                   CI: true

--- a/cypress/e2e/styling.cy.js
+++ b/cypress/e2e/styling.cy.js
@@ -61,7 +61,8 @@ context('Styling', () => {
             .should('contain', 'line-height: 1.5rem');
     });
 
-    it('Font family can be changed', () => {
+    it.only('Font family can be changed', () => {
+        cy.addCode('const foo = "bar";');
         cy.openSideBarPanel('Styling');
 
         cy.getPostContent('.wp-block[class$="code-block-pro"]')
@@ -72,9 +73,20 @@ context('Styling', () => {
             .select('Fira Code')
             .should('have.value', 'Code-Pro-Fira-Code');
 
-        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+        cy.previewCurrentPage();
+
+        cy.get('.wp-block-kevinbatdorf-code-block-pro')
             .invoke('attr', 'style')
-            .should('contain', 'font-family: Code-Pro-Fira-Code');
+            .should('contain', 'font-family:Code-Pro-Fira-Code');
+
+        cy.go('back');
+
+        cy.focusBlock('code-block-pro', 'textarea');
+        cy.get('.wp-block[class$="code-block-pro"] textarea').should(
+            'have.focus',
+        );
+
+        cy.openSideBarPanel('Styling');
 
         cy.get('#code-block-pro-font-family')
             .select('JetBrains Mono')
@@ -82,7 +94,9 @@ context('Styling', () => {
             .select('System Default')
             .should('have.value', '');
 
-        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+        cy.previewCurrentPage();
+
+        cy.get('.wp-block-kevinbatdorf-code-block-pro')
             .invoke('attr', 'style')
             .should('not.contain', 'font-family');
     });

--- a/cypress/e2e/styling.cy.js
+++ b/cypress/e2e/styling.cy.js
@@ -61,7 +61,7 @@ context('Styling', () => {
             .should('contain', 'line-height: 1.5rem');
     });
 
-    it.only('Font family can be changed', () => {
+    it('Font family can be changed', () => {
         cy.addCode('const foo = "bar";');
         cy.openSideBarPanel('Styling');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
                 "eslint": "8.32.0",
                 "eslint-config-prettier": "8.6.0",
                 "eslint-plugin-cypress": "2.12.1",
+                "eslint-plugin-no-only-tests": "^3.1.0",
                 "eslint-plugin-prettier": "4.2.1",
                 "eslint-plugin-react": "7.32.1",
                 "eslint-plugin-react-hooks": "4.6.0",
@@ -10247,6 +10248,15 @@
             },
             "peerDependencies": {
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+            }
+        },
+        "node_modules/eslint-plugin-no-only-tests": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+            "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+            "dev": true,
+            "engines": {
+                "node": ">=5.0.0"
             }
         },
         "node_modules/eslint-plugin-prettier": {
@@ -29101,6 +29111,12 @@
                 "object.fromentries": "^2.0.6",
                 "semver": "^6.3.0"
             }
+        },
+        "eslint-plugin-no-only-tests": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+            "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+            "dev": true
         },
         "eslint-plugin-prettier": {
             "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "eslint": "8.32.0",
         "eslint-config-prettier": "8.6.0",
         "eslint-plugin-cypress": "2.12.1",
+        "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-react": "7.32.1",
         "eslint-plugin-react-hooks": "4.6.0",

--- a/readme.txt
+++ b/readme.txt
@@ -247,6 +247,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Fix: Disabled font ligatures int he editor as it broke cursor positioning on wraps
+
 = 1.12.0 - 2023-01-28 =
 - Feature: Added Ara, Power Query, and DAX language support
 - Fix: Fixed preview output on theme selection

--- a/src/editor/components/FontSelect.tsx
+++ b/src/editor/components/FontSelect.tsx
@@ -120,10 +120,7 @@ export const FontFamilySelect = ({
         <SelectControl
             id="code-block-pro-font-family"
             label={__('Font Family', 'code-block-pro')}
-            help={__(
-                'Fonts only show on the front end of your site.',
-                'code-block-pro',
-            )}
+            help={__('Fonts only render on the frontend.', 'code-block-pro')}
             value={value}
             onChange={onChange}
             options={Object.entries(fonts).map(([value, label]) => ({

--- a/src/editor/components/FontSelect.tsx
+++ b/src/editor/components/FontSelect.tsx
@@ -120,6 +120,10 @@ export const FontFamilySelect = ({
         <SelectControl
             id="code-block-pro-font-family"
             label={__('Font Family', 'code-block-pro')}
+            help={__(
+                'Fonts only show on the front end of your site.',
+                'code-block-pro',
+            )}
             value={value}
             onChange={onChange}
             options={Object.entries(fonts).map(([value, label]) => ({

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -68,7 +68,7 @@
     left: -16px;
     @apply absolute top-0 h-full;
 }
-.wp-block-kevinbatdorf-code-block-pro.padding-disabled pre .line.cbp-line-highlight::after {
+.wp-block-kevinbatdorf-code-block-pro:not(.code-block-pro-editor).padding-disabled pre .line.cbp-line-highlight::after {
     @apply left-0 w-full;
 }
 .wp-block-kevinbatdorf-code-block-pro.cbp-blur-enabled pre .line:not(.cbp-no-blur) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -103,8 +103,7 @@ registerBlockType<Attributes>(blockConfig.name, {
                                 ? attributes.lineHighlightColor
                                 : undefined,
                         '--cbp-line-height': attributes.lineHeight,
-                        // Disableed as ligatures will break the editor as char widths
-                        // differenciate
+                        // Disabled as ligatures will break the editor line widths
                         // fontFamily: fontFamilyLong(attributes.fontFamily),
                         fontFamily: fontFamilyLong(''),
                         lineHeight: maybeClamp(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -103,7 +103,10 @@ registerBlockType<Attributes>(blockConfig.name, {
                                 ? attributes.lineHighlightColor
                                 : undefined,
                         '--cbp-line-height': attributes.lineHeight,
-                        fontFamily: fontFamilyLong(attributes.fontFamily),
+                        // Disableed as ligatures will break the editor as char widths
+                        // differenciate
+                        // fontFamily: fontFamilyLong(attributes.fontFamily),
+                        fontFamily: fontFamilyLong(''),
                         lineHeight: maybeClamp(
                             attributes.lineHeight,
                             attributes.clampFonts,


### PR DESCRIPTION
This fixes a bug where in the editor the font ligatures would cause a mismatch on line width and the cursor placement would get wonky. A textarea can't render font ligs so no choice really but to disable that in the editor. 

closes https://github.com/KevinBatdorf/code-block-pro/issues/109