### PR TITLE
Update max height sidebar ui

### DIFF
--- a/src/editor/components/HeightPanel.tsx
+++ b/src/editor/components/HeightPanel.tsx
@@ -57,11 +57,11 @@ export const HeightPanel = ({
                     autoComplete="off"
                     data-cy-cbp="editor-height"
                     type="number"
-                    label={__('Max editor height', 'code-block-pro')}
-                    help={__(
-                        'Admin only. Set to 0 to disable.',
+                    label={__(
+                        'Max editor height (admin only)',
                         'code-block-pro',
                     )}
+                    help={__('Set to 0 to disable.', 'code-block-pro')}
                     placeholder={'0'}
                     onChange={setEditorHeight}
                     value={editorHeight}
@@ -69,7 +69,11 @@ export const HeightPanel = ({
             </BaseControl>
             <BaseControl id="code-block-pro-see-more-enabled">
                 <CheckboxControl
-                    label={__('Enable max height', 'code-block-pro')}
+                    label={__('Enable frontend max height', 'code-block-pro')}
+                    help={__(
+                        'Enable this, then select a specific line number below.',
+                        'code-block-pro',
+                    )}
                     data-cy="enable-max-height"
                     checked={enableMaxHeight}
                     onChange={setEnableMaxHeight}

--- a/src/editor/components/SeeMoreSelect.tsx
+++ b/src/editor/components/SeeMoreSelect.tsx
@@ -28,7 +28,8 @@ export const SeeMoreSelect = ({ attributes, onClick }: SeeMoreSelectProps) => {
                 <BaseControl
                     id={`code-block-pro-see-more-${slug}`}
                     label={
-                        seeMoreType === slug || !seeMoreType
+                        seeMoreType === slug ||
+                        (!seeMoreType && slug === 'none')
                             ? sprintf(
                                   __('%s (current)', 'code-block-pro'),
                                   type,


### PR DESCRIPTION
This updates the max height sidebar ui a bit. it's still not super intuitive but I think it's more clear now than what's released.

The issue is that the user may want the front end at a max height, but the editor fully expanded so they can edit the code. Or vice versa where they have long code that needs to display in full on the front end but truncated on the back. 

This may be a case of over thinking it though!

<img width="286" alt="Screen Shot 2023-02-18 at 4 19 14 PM" src="https://user-images.githubusercontent.com/1478421/219853091-95616bb5-a2de-45b1-9b68-9401070bf03f.png">
