### PR TITLE
Update failing tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                wp-version: [null, '"WordPress/WordPress#master"']
+                wp-version: [null, '"WordPress/WordPress#6.2-branch"']
         steps:
             - name: Clone repo
               uses: actions/checkout@v3

--- a/cypress/e2e/footers.cy.js
+++ b/cypress/e2e/footers.cy.js
@@ -14,15 +14,18 @@ afterEach(() => {
 });
 context('Footers', () => {
     it('Renders no footer on insert and can swap', () => {
-        cy.getPostContent('.wp-block[class$="code-block-pro"] > div')
+        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+            .find('div')
             .siblings()
             .should('have.length', 2);
         cy.setFooter('simpleStringEnd');
-        cy.getPostContent('.wp-block[class$="code-block-pro"] > div')
+        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+            .find('div')
             .siblings()
             .should('have.length', 3);
         cy.setFooter('none');
-        cy.getPostContent('.wp-block[class$="code-block-pro"] > div')
+        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+            .find('div')
             .siblings()
             .should('have.length', 2);
     });

--- a/cypress/e2e/themes.cy.js
+++ b/cypress/e2e/themes.cy.js
@@ -54,7 +54,7 @@ context('Theme checks', () => {
             'Manage Themes',
         );
         cy.get('#code-block-pro-theme-manager label').contains('Nord').click();
-        cy.get('[aria-label="Close dialog"]').click();
+        cy.get('.code-block-pro-editor [aria-label^="Close"]').click();
         cy.get('#code-block-pro-theme-nord').should('not.exist');
     });
 
@@ -71,7 +71,7 @@ context('Theme checks', () => {
         cy.get(`[href^="${MORE_THEMES_URL}"]`).should('have.length', 2);
         cy.get('[data-cy="manage-themes"]').should('exist').click();
         cy.get(`[href^="${MORE_THEMES_URL}"]`).should('exist');
-        cy.get('[aria-label="Close dialog"]').click();
+        cy.get('.code-block-pro-editor [aria-label^="Close"]').click();
     });
 
     it('Theme CTA "more themes" link can be removed', () => {
@@ -85,7 +85,7 @@ context('Theme checks', () => {
             cy.get(`[href^="${MORE_THEMES_URL}"]`).should('not.exist');
             cy.get('[data-cy="manage-themes"]').should('exist').click();
             cy.get(`[href^="${MORE_THEMES_URL}"]`).should('not.exist');
-            cy.get('[aria-label="Close dialog"]').click();
+            cy.get('.code-block-pro-editor [aria-label^="Close"]').click();
         });
     });
 

--- a/cypress/support/gutenberg.js
+++ b/cypress/support/gutenberg.js
@@ -26,13 +26,17 @@ export const closeWelcomeGuide = () => {
             ) {
                 return true;
             }
+            console.log(
+                win.wp.data
+                    .select('core/edit-post')
+                    .isFeatureActive('welcomeGuide'),
+            );
             win.wp.data
                 .dispatch('core/edit-post')
                 .toggleFeature('welcomeGuide');
-
-            // And wait again for the animation to finish
-            cy.get(className).should('not.exist');
         });
+        // And wait again for the animation to finish
+        cy.get(className).should('not.exist');
     });
 };
 

--- a/cypress/support/gutenberg.js
+++ b/cypress/support/gutenberg.js
@@ -26,11 +26,6 @@ export const closeWelcomeGuide = () => {
             ) {
                 return true;
             }
-            console.log(
-                win.wp.data
-                    .select('core/edit-post')
-                    .isFeatureActive('welcomeGuide'),
-            );
             win.wp.data
                 .dispatch('core/edit-post')
                 .toggleFeature('welcomeGuide');

--- a/src/editor/controls/Toolbar.tsx
+++ b/src/editor/controls/Toolbar.tsx
@@ -32,7 +32,7 @@ export const ToolbarControls = ({
                             onClick={onToggle}
                             aria-expanded={isOpen}
                             aria-haspopup="true">
-                            {(languages[language] ?? language).replace(
+                            {(languages[language] ?? language)?.replace(
                                 'ANSI',
                                 'ANSI (experimental)',
                             )}


### PR DESCRIPTION
This tweaks the tests to test for RC WP versions instead of the main branch. 

TODO: I wonder if I can fetch the latest tag first within the GH action and use that rather than hard code the branch