### PR TITLE
Break up cypress workflow jobs

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -9,12 +9,24 @@ jobs:
     test:
         name: Cypress
         concurrency:
-            group: cypress - ${{ github.event.pull_request.number || github.ref }} - ${{ matrix.wp-version }}
+            group: cypress - ${{ github.event.pull_request.number || github.ref }} - ${{ matrix.wp-version }} - ${{ matrix.spec }}
             cancel-in-progress: true
         runs-on: ubuntu-latest
         strategy:
             matrix:
                 wp-version: [null, '"WordPress/WordPress#6.2-branch"']
+                spec: [
+                  "compatability",
+                  "copy-button",
+                  "footers",
+                  "headers",
+                  "height",
+                  "language",
+                  "lines",
+                  "padding",
+                  "styling",
+                  "themes",
+                ]
         steps:
             - name: Clone repo
               uses: actions/checkout@v3
@@ -45,7 +57,7 @@ jobs:
             - name: Cypress run
               uses: cypress-io/github-action@v4
               with:
-                browser: chrome
+                spec: cypress/e2e/${{ matrix.spec }}.cy.js
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - uses: actions/upload-artifact@v3

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,6 +8,7 @@ on:
 jobs:
     test:
         name: Cypress
+        continue-on-error: true
         concurrency:
             group: cypress - ${{ github.event.pull_request.number || github.ref }} - ${{ matrix.wp-version }} - ${{ matrix.spec }}
             cancel-in-progress: true


### PR DESCRIPTION
This should run each spec in isolation so random failures unrelated to the PR can be re-run more quickly