### PR TITLE
Disable workflow fail fast

### DIFF
--- a/.github/workflows/cypress-main.yml
+++ b/.github/workflows/cypress-main.yml
@@ -10,12 +10,12 @@ on:
 jobs:
     test:
         name: WordPress ${{ matrix.wp-version }} (${{ matrix.spec }})
-        fail-fast: false
         concurrency:
             group: cypress - ${{ github.event.pull_request.number || github.ref }} - ${{ matrix.wp-version }} - ${{ matrix.spec }}
             cancel-in-progress: true
         runs-on: ubuntu-latest
         strategy:
+            fail-fast: false
             matrix:
                 wp-version: [null, 'Next']
                 spec: [

--- a/.github/workflows/cypress-main.yml
+++ b/.github/workflows/cypress-main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     test:
         name: WordPress ${{ matrix.wp-version }} (${{ matrix.spec }})
-        continue-on-error: true
+        fail-fast: false
         concurrency:
             group: cypress - ${{ github.event.pull_request.number || github.ref }} - ${{ matrix.wp-version }} - ${{ matrix.spec }}
             cancel-in-progress: true

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -7,7 +7,6 @@ on:
 jobs:
     test:
         name: WordPress (${{ matrix.spec }})
-        continue-on-error: true
         concurrency:
             group: cypress - ${{ github.event.pull_request.number || github.ref }} - ${{ matrix.spec }}
             cancel-in-progress: true

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -12,6 +12,7 @@ jobs:
             cancel-in-progress: true
         runs-on: ubuntu-latest
         strategy:
+            fail-fast: false
             matrix:
                 spec: [
                   "compatability",


### PR DESCRIPTION
`continue-on-error` will ignore failures completely, while `fail-fast: false` will not stop other runs, but will fail the job globally (and more importantly, email + show the red check on the PR)