### PR TITLE
Add plaintext option

### DIFF
--- a/src/defaultLanguages.json
+++ b/src/defaultLanguages.json
@@ -106,6 +106,7 @@
     "perl": "Perl",
     "php": "PHP",
     "plsql": "PLSQL",
+    "plaintext": "Plain text",
     "postcss": "PostCSS",
     "powershell": "PowerShell",
     "ps": "PowerShell",

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,8 +1,9 @@
 import { useEffect, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
-import { getHighlighter, Lang, setCDN, Theme, setWasm } from 'shiki';
+import { getHighlighter, setCDN, Theme, setWasm } from 'shiki';
 import useSWRImmutable from 'swr/immutable';
 import defaultThemes from '../defaultThemes.json';
+import { Lang } from '../types';
 import { getEditorLanguage } from '../util/languages';
 
 type Params = { theme: Theme; lang: Lang | 'ansi'; ready?: boolean };
@@ -23,7 +24,7 @@ const fetcher = ({ theme, lang, ready }: Params) => {
     )?.[themeFiltered]?.['alias'] as Theme;
 
     return getHighlighter({
-        langs: [getEditorLanguage(lang)],
+        langs: lang === 'plaintext' ? undefined : [getEditorLanguage(lang)],
         theme: themeAlias ?? themeFiltered,
     });
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Lang as LangShiki, Theme } from 'shiki';
 
-export type Lang = LangShiki | 'ansi';
+export type Lang = LangShiki | 'ansi' | 'plaintext';
 
 export type Attributes = {
     code: string;


### PR DESCRIPTION
This adds a plaintext option, which essentially just doesn't use any language

![Screen Shot 2023-03-29 at 8 55 41 AM](https://user-images.githubusercontent.com/1478421/228542051-94e5a52d-335c-4b71-9e20-8e36b44a97f7.png)
![Screen Shot 2023-03-29 at 8 55 33 AM](https://user-images.githubusercontent.com/1478421/228542057-a708eea4-9eb7-49e5-a1be-82dfcbd7e3d0.png)


closes #162 