### PR TITLE
Add no permissions notice

### DIFF
--- a/.github/workflows/cypress-main.yml
+++ b/.github/workflows/cypress-main.yml
@@ -27,6 +27,7 @@ jobs:
                   "language",
                   "lines",
                   "padding",
+                  "permissions",
                   "styling",
                   "themes",
                 ]

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -2,7 +2,7 @@ name: Run Cypress on push
 on:
     push:
         branches-ignore:
-          - main
+            - main
     workflow_dispatch:
 jobs:
     test:
@@ -14,19 +14,20 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                spec: [
-                  "compatability",
-                  "copy-button",
-                  "footers",
-                  "headers",
-                  "height",
-                  "language",
-                  "lines",
-                  "padding",
-                  "permissions",
-                  "styling",
-                  "themes",
-                ]
+                spec:
+                    [
+                        'compatability',
+                        'copy-button',
+                        'footers',
+                        'headers',
+                        'height',
+                        'language',
+                        'lines',
+                        'padding',
+                        'permissions',
+                        'styling',
+                        'themes',
+                    ]
         steps:
             - name: Clone repo
               uses: actions/checkout@v3
@@ -42,7 +43,7 @@ jobs:
             - name: Cypress run
               uses: cypress-io/github-action@v4
               with:
-                spec: cypress/e2e/${{ matrix.spec }}.cy.js
+                  spec: cypress/e2e/${{ matrix.spec }}.cy.js
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - uses: actions/upload-artifact@v3

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -23,6 +23,7 @@ jobs:
                   "language",
                   "lines",
                   "padding",
+                  "permissions",
                   "styling",
                   "themes",
                 ]

--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -26,6 +26,7 @@ add_action('init', function () {
 add_action('admin_init', function () {
     wp_add_inline_script('kevinbatdorf-code-block-pro-editor-script', 'window.codeBlockPro = ' . wp_json_encode([
         'pluginUrl' => esc_url_raw(plugin_dir_url(__FILE__)),
+        'canSaveHtml' => current_user_can('unfiltered_html'),
     ]) . ';');
 });
 

--- a/cypress/e2e/lines.cy.js
+++ b/cypress/e2e/lines.cy.js
@@ -19,7 +19,7 @@ context('Line numbers', () => {
 
         cy.get('[data-cy="show-line-numbers"]')
             .should('exist')
-            .should('be.not.checked');
+            .should('not.be.checked');
         cy.getPostContent('.wp-block[class$="code-block-pro"]').should(
             'not.have.class',
             'cbp-has-line-numbers',

--- a/cypress/e2e/permissions.cy.js
+++ b/cypress/e2e/permissions.cy.js
@@ -1,0 +1,39 @@
+beforeEach(() => {
+    cy.resetDatabase();
+    cy.clearBrowserStorage();
+    cy.updateUserRole('author');
+    cy.loginUser();
+    cy.visitNewPostEditor();
+});
+afterEach(() => {
+    cy.saveDraft(); // so we can leave without an alert
+    cy.logoutUser();
+});
+context('Permissions', () => {
+    it('Warning shows when cap is missing', () => {
+        cy.addBlock('kevinbatdorf/code-block-pro');
+        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+            .invoke('html')
+            .should('contain', 'capability is required to edit this block');
+    });
+
+    it('Prevents updating attributes', () => {
+        cy.addBlock('kevinbatdorf/code-block-pro');
+        cy.openSideBarPanel('Line Settings');
+
+        // ported from lines spec with the final assertions updated
+        cy.get('[data-cy="show-line-numbers"]')
+            .should('exist')
+            .should('not.be.checked');
+        cy.getPostContent('.wp-block[class$="code-block-pro"]').should(
+            'not.have.class',
+            'cbp-has-line-numbers',
+        );
+
+        cy.get('[data-cy="show-line-numbers"]').check().should('be.checked');
+        cy.getPostContent('.wp-block[class$="code-block-pro"]').should(
+            'not.have.class', // changed here
+            'cbp-has-line-numbers',
+        );
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -21,11 +21,12 @@ import { mockIntersectionObserver } from './helpers';
 import { login, logout } from './login-logout';
 import {
     visitPageEditor,
+    visitPostEditor,
     visitAdminPage,
     visitToLoginPage,
 } from './navigate-pages';
 import { installPlugin, uninstallPlugin } from './plugins';
-import { resetDatabase } from './wp-cli';
+import { resetDatabase, updateUserRole } from './wp-cli';
 
 // Port more commands from WP here:
 // https://github.com/WordPress/gutenberg/tree/trunk/packages/e2e-test-utils/src
@@ -35,9 +36,8 @@ Cypress.Commands.add('visitLoginPage', (query) => visitToLoginPage(query));
 Cypress.Commands.add('visitAdminPage', (path, query) =>
     visitAdminPage(path, query),
 );
-Cypress.Commands.add('visitNewPageEditor', (query, skipWelcomeGuide) =>
-    visitPageEditor(query, skipWelcomeGuide),
-);
+Cypress.Commands.add('visitNewPageEditor', (query) => visitPageEditor(query));
+Cypress.Commands.add('visitNewPostEditor', (query) => visitPostEditor(query));
 
 // Login logout
 Cypress.Commands.add('loginUser', (username, password) =>
@@ -79,6 +79,7 @@ Cypress.Commands.add('mockIntersectionObserver', () =>
 
 // Server
 Cypress.Commands.add('resetDatabase', () => resetDatabase());
+Cypress.Commands.add('updateUserRole', (cap) => updateUserRole(cap));
 
 // Manage plugins
 Cypress.Commands.add('installPlugin', (slug) => installPlugin(slug));

--- a/cypress/support/navigate-pages.js
+++ b/cypress/support/navigate-pages.js
@@ -10,15 +10,16 @@ export const visitAdminPage = (adminPath = '', query = '') => {
     cy.visit(`wp-admin/${adminPath}${question}${query}`);
 };
 
-export const visitPageEditor = (query, skipWelcomeGuide = true) => {
+const visitEditor = (query) => {
     query = addQueryArgs('', {
         post_type: 'page',
         ...query,
     }).slice(1);
 
     cy.visitAdminPage('post-new.php', query);
-
-    if (skipWelcomeGuide) {
-        cy.closeWelcomeGuide();
-    }
+    cy.closeWelcomeGuide();
 };
+export const visitPageEditor = (query) =>
+    visitEditor({ ...query, post_type: 'page' });
+export const visitPostEditor = (query) =>
+    visitEditor({ ...query, post_type: 'post' });

--- a/cypress/support/wp-cli.js
+++ b/cypress/support/wp-cli.js
@@ -1,1 +1,3 @@
 export const resetDatabase = () => cy.exec('wp-env clean all');
+export const updateUserRole = (role) =>
+    cy.exec(`wp-env run cli user set-role 1 ${role}`);

--- a/readme.txt
+++ b/readme.txt
@@ -250,6 +250,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Feature: Add notice to users who do not have permission to update
+
 = 1.14.0 - 2023-03-26 =
 - Feature: Added theme identifier to toolbar
 - Feature: Added some filters for attributes and buttons

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -16,11 +16,13 @@ import { useLanguageStore } from '../state/language';
 import { AttributesPropsAndSetter, Lang } from '../types';
 import { parseJSONArrayWithRanges } from '../util/arrayHelpers';
 import { getEditorLanguage } from '../util/languages';
+import { MissingPermissionsTip } from './components/misc/MissingPermissions';
 
 export const Edit = ({
     attributes,
     setAttributes,
-}: AttributesPropsAndSetter) => {
+    canEdit,
+}: AttributesPropsAndSetter & { canEdit: boolean }) => {
     const {
         language,
         theme,
@@ -204,6 +206,11 @@ export const Edit = ({
                     : undefined,
                 overflow: Number(editorHeight) ? 'auto' : undefined,
             }}>
+            {canEdit ? null : (
+                <div className="absolute inset-0 z-10 bg-white bg-opacity-70">
+                    <MissingPermissionsTip />
+                </div>
+            )}
             <Editor
                 value={decodeEntities(code)}
                 onValueChange={handleChange}
@@ -218,7 +225,11 @@ export const Edit = ({
                     })(),
                     right: 0,
                 }}
-                style={{ backgroundColor, color }}
+                style={{
+                    backgroundColor,
+                    color,
+                    minHeight: canEdit ? undefined : 200,
+                }}
                 // eslint-disable-next-line
                 onKeyDown={(e: any) =>
                     e.key === 'Tab' &&

--- a/src/editor/components/misc/MissingPermissions.tsx
+++ b/src/editor/components/misc/MissingPermissions.tsx
@@ -1,0 +1,23 @@
+import { Tip, Card, CardBody } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+export const MissingPermissionsTip = () => (
+    <Card>
+        <CardBody>
+            <Tip>
+                <span
+                    className="text-sm"
+                    dangerouslySetInnerHTML={{
+                        __html: sprintf(
+                            __(
+                                'The %s capability is required to edit this block. Contact an admin to enable this feature. This is not an error.',
+                                'code-block-pro',
+                            ),
+                            '<code>unfiltered_html</code>',
+                        ),
+                    }}
+                />
+            </Tip>
+        </CardBody>
+    </Card>
+);

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -23,13 +23,15 @@ import { FooterSelect } from '../components/FooterSelect';
 import { HeaderSelect } from '../components/HeaderSelect';
 import { HeightPanel } from '../components/HeightPanel';
 import { ThemesPanel } from '../components/ThemesPanel';
+import { MissingPermissionsTip } from '../components/misc/MissingPermissions';
 import { BlurControl } from './BlurControl';
 import { HighlightingControl } from './HighlightingControl';
 
 export const SidebarControls = ({
     attributes,
     setAttributes,
-}: AttributesPropsAndSetter) => {
+    canEdit,
+}: AttributesPropsAndSetter & { canEdit: boolean }) => {
     const [language, setLanguage] = useLanguage({ attributes, setAttributes });
     const { recentLanguages } = useLanguageStore();
     const { updateThemeHistory } = useThemeStore();
@@ -45,6 +47,7 @@ export const SidebarControls = ({
 
     return (
         <InspectorControls>
+            {canEdit ? null : <MissingPermissionsTip />}
             <PanelBody
                 title={__('Settings', 'code-block-pro')}
                 initialOpen={true}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,71 +68,82 @@ registerBlockType<Attributes>(blockConfig.name, {
         align: ['wide', 'full'],
     },
     title: __('Code Pro', 'code-block-pro'),
-    edit: ({ attributes, setAttributes }) => (
-        <>
-            <SidebarControls
-                attributes={attributes}
-                setAttributes={setAttributes}
-            />
-            <ToolbarControls
-                attributes={attributes}
-                setAttributes={setAttributes}
-            />
-            <div
-                {...blockProps({
-                    className: classnames('code-block-pro-editor', {
-                        'padding-disabled': attributes.disablePadding,
-                        'padding-bottom-disabled':
-                            attributes?.footerType &&
-                            attributes?.footerType !== 'none',
-                        'cbp-has-line-numbers': attributes.lineNumbers,
-                        'cbp-blur-enabled': attributes.enableBlurring,
-                        'cbp-unblur-on-hover': attributes.removeBlurOnHover,
-                    }),
-                    style: {
-                        fontSize: maybeClamp(
-                            attributes.fontSize,
-                            attributes.clampFonts,
-                        ),
-                        '--cbp-line-number-color': attributes?.lineNumbers
-                            ? attributes.textColor
-                            : undefined,
-                        '--cbp-line-number-start':
-                            Number(attributes?.startingLineNumber) > 1
-                                ? attributes.startingLineNumber
+    edit: ({ attributes, setAttributes }) => {
+        // Restricts users without unfiltered HTML access
+        const hasPermission = window.codeBlockPro.canSaveHtml;
+        setAttributes = hasPermission ? setAttributes : () => undefined;
+        return (
+            <>
+                <SidebarControls
+                    attributes={attributes}
+                    canEdit={hasPermission}
+                    setAttributes={setAttributes}
+                />
+                <ToolbarControls
+                    attributes={attributes}
+                    setAttributes={setAttributes}
+                />
+                <div
+                    {...blockProps({
+                        className: classnames('code-block-pro-editor', {
+                            'padding-disabled': attributes.disablePadding,
+                            'padding-bottom-disabled':
+                                attributes?.footerType &&
+                                attributes?.footerType !== 'none',
+                            'cbp-has-line-numbers': attributes.lineNumbers,
+                            'cbp-blur-enabled': attributes.enableBlurring,
+                            'cbp-unblur-on-hover': attributes.removeBlurOnHover,
+                        }),
+                        style: {
+                            fontSize: maybeClamp(
+                                attributes.fontSize,
+                                attributes.clampFonts,
+                            ),
+                            '--cbp-line-number-color': attributes?.lineNumbers
+                                ? attributes.textColor
                                 : undefined,
-                        '--cbp-line-number-width': attributes.lineNumbersWidth
-                            ? `${attributes.lineNumbersWidth}px`
-                            : undefined,
-                        '--cbp-line-highlight-color':
-                            attributes?.enableHighlighting
-                                ? attributes.lineHighlightColor
-                                : undefined,
-                        '--cbp-line-height': attributes.lineHeight,
-                        // Disabled as ligatures will break the editor line widths
-                        // fontFamily: fontFamilyLong(attributes.fontFamily),
-                        fontFamily: fontFamilyLong(''),
-                        lineHeight: maybeClamp(
-                            attributes.lineHeight,
-                            attributes.clampFonts,
-                        ),
-                        ...(applyFilters(
-                            'blocks.codeBlockPro.additionalEditorAttributes',
-                            {},
-                            attributes,
-                        ) as object),
-                    },
-                })}>
-                <HeaderType {...attributes} />
-                {attributes.copyButton && (
-                    <CopyButton attributes={attributes} />
-                )}
-                <Edit attributes={attributes} setAttributes={setAttributes} />
-                <FooterType {...attributes} />
-                <SeeMoreType {...attributes} />
-            </div>
-        </>
-    ),
+                            '--cbp-line-number-start':
+                                Number(attributes?.startingLineNumber) > 1
+                                    ? attributes.startingLineNumber
+                                    : undefined,
+                            '--cbp-line-number-width':
+                                attributes.lineNumbersWidth
+                                    ? `${attributes.lineNumbersWidth}px`
+                                    : undefined,
+                            '--cbp-line-highlight-color':
+                                attributes?.enableHighlighting
+                                    ? attributes.lineHighlightColor
+                                    : undefined,
+                            '--cbp-line-height': attributes.lineHeight,
+                            // Disabled as ligatures will break the editor line widths
+                            // fontFamily: fontFamilyLong(attributes.fontFamily),
+                            fontFamily: fontFamilyLong(''),
+                            lineHeight: maybeClamp(
+                                attributes.lineHeight,
+                                attributes.clampFonts,
+                            ),
+                            ...(applyFilters(
+                                'blocks.codeBlockPro.additionalEditorAttributes',
+                                {},
+                                attributes,
+                            ) as object),
+                        },
+                    })}>
+                    <HeaderType {...attributes} />
+                    {attributes.copyButton && (
+                        <CopyButton attributes={attributes} />
+                    )}
+                    <Edit
+                        attributes={attributes}
+                        setAttributes={setAttributes}
+                        canEdit={hasPermission}
+                    />
+                    <FooterType {...attributes} />
+                    <SeeMoreType {...attributes} />
+                </div>
+            </>
+        );
+    },
     save: ({ attributes }) => <BlockOutput attributes={attributes} />,
     transforms: {
         from: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ declare global {
     interface Window {
         codeBlockPro: {
             pluginUrl: string;
+            canSaveHtml: boolean;
         };
     }
 }


### PR DESCRIPTION
This adds a notice to users who have permission to edit a page but not `unfiltered_html` permission. It also blocks access to updating attributes (although it's easily enough to bypass - the db blocks dangerous html regardless).

The issue is mainly SVGs though

![Screen Shot 2023-04-07 at 1 43 36 AM](https://user-images.githubusercontent.com/1478421/230548843-e6e3ed16-1ed8-47bd-8b1a-dec90bee8b5e.png)

closes https://github.com/KevinBatdorf/code-block-pro/issues/165