### PR TITLE
Add custom theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Code highlighting powered by the VS Code engine
 
-Read more at [code-block-pro.com](https://code-block-pro.com?utm_campaign=plugin&utm_source=gh-readme&utm_medium=textlink)
+Read more at [code-block-pro.com](https://code-block-pro.com?utm_campaign=github&utm_source=gh-readme&utm_medium=textlink)
 
 View all themes at [code-block-pro.com/themes](https://code-block-pro.com/themes?utm_campaign=themes&utm_source=gh-readme&utm_medium=textlink)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "@trivago/prettier-plugin-sort-imports": "4.1.1",
                 "@types/wordpress__block-editor": "11.5.0",
                 "@types/wordpress__blocks": "12.5.0",
+                "@types/wordpress__edit-post": "^7.0.2",
                 "@typescript-eslint/parser": "5.56.0",
                 "@wordpress/block-editor": "11.6.0",
                 "@wordpress/env": "5.14.0",
@@ -4880,6 +4881,78 @@
                 "redux": "^4.1.0"
             }
         },
+        "node_modules/@types/wordpress__edit-post": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/wordpress__edit-post/-/wordpress__edit-post-7.0.2.tgz",
+            "integrity": "sha512-K3y+xM7afo8YZA4QnsrkhKUWb6TF9HQDHiG0HSGFRb7eyYynx1rpByC5vJW1AZg81OqvsAsYyzscHIbiS1jFZw==",
+            "dev": true,
+            "dependencies": {
+                "@types/react": "*",
+                "@types/wordpress__components": "*",
+                "@wordpress/data": "^9.0.0",
+                "@wordpress/element": "^5.0.0"
+            }
+        },
+        "node_modules/@types/wordpress__edit-post/node_modules/@wordpress/data": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.0.0.tgz",
+            "integrity": "sha512-+FBLxCNZSGhI5b6+Bx2lE4PhmbPTCl7WqEcDByiTp4EGotJXtDaanUukxv3sI5qDrX8nKroqN8uytxIL2raHlg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@wordpress/compose": "^6.7.0",
+                "@wordpress/deprecated": "^3.30.0",
+                "@wordpress/element": "^5.7.0",
+                "@wordpress/is-shallow-equal": "^4.30.0",
+                "@wordpress/priority-queue": "^2.30.0",
+                "@wordpress/private-apis": "^0.12.0",
+                "@wordpress/redux-routine": "^4.30.0",
+                "deepmerge": "^4.3.0",
+                "equivalent-key-map": "^0.2.2",
+                "is-plain-object": "^5.0.0",
+                "is-promise": "^4.0.0",
+                "redux": "^4.1.2",
+                "turbo-combine-reducers": "^1.0.2",
+                "use-memo-one": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "node_modules/@types/wordpress__edit-post/node_modules/@wordpress/element": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.7.0.tgz",
+            "integrity": "sha512-sztnsbrmvsiZIxXGvvKx4D/xfhKIKEylDh15Y6PqUpxMqznmnf5/+fxLc9zeVAkV/c+Yd8xp3DxUH230tCAkpQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@types/react": "^18.0.21",
+                "@types/react-dom": "^18.0.6",
+                "@wordpress/escape-html": "^2.30.0",
+                "change-case": "^4.1.2",
+                "is-plain-object": "^5.0.0",
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@types/wordpress__edit-post/node_modules/@wordpress/private-apis": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.12.0.tgz",
+            "integrity": "sha512-x0nPVPiJA1ntL62xMCueNGuFlIDDqdfHXtk38X08tRCU+S6ILO0MZ9AGMhAl4nsWb8S6D+7t9iB9K0Y/wmDO2g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.16.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@types/wordpress__keycodes": {
             "version": "2.3.1",
             "dev": true,
@@ -5832,18 +5905,18 @@
             "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
         },
         "node_modules/@wordpress/compose": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.6.0.tgz",
-            "integrity": "sha512-+LsVWPf4IhL7Br3RB89m+If/6Swspu0wB2nSd28z3spHP92ndszp0Lli6rrFRRkDPWEva/b+bfxv8oDFBx3qCg==",
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.7.0.tgz",
+            "integrity": "sha512-Uas6Lc7V4vVlnfjbey9AK8Pm1w85FoSCBYenWO3jx1ZR/C9djDoQEczDqiJk1jsEGNUtNKSaS+6O4/ubQ9NkyA==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "@types/mousetrap": "^1.6.8",
-                "@wordpress/deprecated": "^3.29.0",
-                "@wordpress/dom": "^3.29.0",
-                "@wordpress/element": "^5.6.0",
-                "@wordpress/is-shallow-equal": "^4.29.0",
-                "@wordpress/keycodes": "^3.29.0",
-                "@wordpress/priority-queue": "^2.29.0",
+                "@wordpress/deprecated": "^3.30.0",
+                "@wordpress/dom": "^3.30.0",
+                "@wordpress/element": "^5.7.0",
+                "@wordpress/is-shallow-equal": "^4.30.0",
+                "@wordpress/keycodes": "^3.30.0",
+                "@wordpress/priority-queue": "^2.30.0",
                 "change-case": "^4.1.2",
                 "clipboard": "^2.0.8",
                 "mousetrap": "^1.6.5",
@@ -5854,6 +5927,24 @@
             },
             "peerDependencies": {
                 "react": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/compose/node_modules/@wordpress/element": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.7.0.tgz",
+            "integrity": "sha512-sztnsbrmvsiZIxXGvvKx4D/xfhKIKEylDh15Y6PqUpxMqznmnf5/+fxLc9zeVAkV/c+Yd8xp3DxUH230tCAkpQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@types/react": "^18.0.21",
+                "@types/react-dom": "^18.0.6",
+                "@wordpress/escape-html": "^2.30.0",
+                "change-case": "^4.1.2",
+                "is-plain-object": "^5.0.0",
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@wordpress/core-data": {
@@ -5946,24 +6037,35 @@
             }
         },
         "node_modules/@wordpress/deprecated": {
-            "version": "3.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.29.0.tgz",
-            "integrity": "sha512-2rn5xhe1r8xQnmI+JRjkMDC099AoO4+KTeBmqz7zDsKoelc5ECXNUak4tj7DpAehh23DQnyBvXkl/CX6Hf9UwQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.30.0.tgz",
+            "integrity": "sha512-+Zk2wqDtvEkq9BY0SHeKHvywPn37hIsDkCyrRHChNhZYYluAzLS9mZKkFKjIuj6+dxYMINbkWcljA+HO0kdcQQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/hooks": "^3.29.0"
+                "@wordpress/hooks": "^3.30.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@wordpress/deprecated/node_modules/@wordpress/hooks": {
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.30.0.tgz",
+            "integrity": "sha512-cvM5OWMQx0D2+wxvsTCI68LXy4cHz1Db97LliiQ+KprSBmYRG5Uy2PqtPv1sMlK8IOypKOlzmG5H5V1CwBN44A==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@wordpress/dom": {
-            "version": "3.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.29.0.tgz",
-            "integrity": "sha512-OBTbirMjAMX/2EOKjj5eCqvpb6ZYh/frxTM2vBsqcmjjn8GOqOi4MHLfX2G1XmtW47Xz1KhrENE7cTqxYDtQtw==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.30.0.tgz",
+            "integrity": "sha512-iO1SW4gr1LiuyuZf0wCaUb/N8tUprt6+nH6d8XMMJN6DCm0dmL/m0DGUYYBTLO0NtbBYCKQah8BaXz5T9qH2cA==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/deprecated": "^3.29.0"
+                "@wordpress/deprecated": "^3.30.0"
             },
             "engines": {
                 "node": ">=12"
@@ -6183,9 +6285,9 @@
             }
         },
         "node_modules/@wordpress/escape-html": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.29.0.tgz",
-            "integrity": "sha512-/zsYF2jXIm7SbLlR0hXHzJpjiSycZ/rPKXWaZRK8EUxzA30FLc7mPiwWY0pmJxi+1mq+q7t8tHhIp01Z64LOBQ==",
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.30.0.tgz",
+            "integrity": "sha512-A0FVcCPSfzCsuoLJOGCKOj3ygg6lWptugtyFcXoELG15AJ3ivfeJEeghZo77YpaWCmyCf0yTC56qbaAa2c48uw==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -6365,9 +6467,9 @@
             }
         },
         "node_modules/@wordpress/is-shallow-equal": {
-            "version": "4.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.29.0.tgz",
-            "integrity": "sha512-aftVUNlivrXIXZT9Xepc6VYoitCX2v6RnT2j7voHSU3lrL6QcWfY4HMiIsIrBbHUCraUxkD0NrFiJ6t3kcOQlw==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.30.0.tgz",
+            "integrity": "sha512-8JxjnS7ncTkw3RJZWMG2mg0eDsip2cTpT2tR4cQte8Ol4Mumz2ByFiTJt3cFPAmqZ3XhBr4bnYurHL0ZUuRzIg==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -6427,13 +6529,43 @@
             }
         },
         "node_modules/@wordpress/keycodes": {
-            "version": "3.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.29.0.tgz",
-            "integrity": "sha512-SZd7FSngpKhI/JjjRRuFojoTrU782ZaYSzxZyyV3ByqIzVs51sxwdjwNNswTPyD3eMTIz1SQb0U8ma0FH0epwA==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.30.0.tgz",
+            "integrity": "sha512-rDZYk/t3a/WtOi8SrfVrHP63mT5NXw13kNf3+VL/jk+hcacb6TXImFEwH0F5nLHVYpvv0fPSoFUDo5bYqwbHZQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/i18n": "^4.29.0",
+                "@wordpress/i18n": "^4.30.0",
                 "change-case": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@wordpress/keycodes/node_modules/@wordpress/hooks": {
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.30.0.tgz",
+            "integrity": "sha512-cvM5OWMQx0D2+wxvsTCI68LXy4cHz1Db97LliiQ+KprSBmYRG5Uy2PqtPv1sMlK8IOypKOlzmG5H5V1CwBN44A==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.30.0.tgz",
+            "integrity": "sha512-vIntwrTBSU2MXOBlpyFntPgimHP+RW+k7/Y00BMPL+xoxPr7J7sXX/GNoYlH1BNsAo7XOi5AY5FrUnQ7ZIYdtQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@wordpress/hooks": "^3.30.0",
+                "gettext-parser": "^1.3.1",
+                "memize": "^1.1.0",
+                "sprintf-js": "^1.1.1",
+                "tannin": "^1.2.0"
+            },
+            "bin": {
+                "pot-to-php": "tools/pot-to-php.js"
             },
             "engines": {
                 "node": ">=12"
@@ -6561,9 +6693,9 @@
             }
         },
         "node_modules/@wordpress/priority-queue": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.29.0.tgz",
-            "integrity": "sha512-vgEQcqpF3JX3tDVQRX09yXBmbw7aBCminlWeXE/oAC9Q6iGY3BuIAUpg4J9uPdjF0mNa0zyLLh/LgiYZynhzOg==",
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.30.0.tgz",
+            "integrity": "sha512-++X/TXeBM4N4PBeLR5NeXE6wzZvvsOhfLo+/hXwcu6lkSumtw/gK7EfN9qxu0O1MRNHFEdIGdKyX8QTTjcCPGw==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "requestidlecallback": "^0.3.0"
@@ -6584,9 +6716,9 @@
             }
         },
         "node_modules/@wordpress/redux-routine": {
-            "version": "4.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.29.0.tgz",
-            "integrity": "sha512-p4FuiNVVCtHs0NSb3W2xbTXagUVHNofX7qVlpr8mREhGk31v8gD2EhHl+M7Fkm45PFJRhoOtIHgSP3t4QBb3+Q==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.30.0.tgz",
+            "integrity": "sha512-m3DBpnCtldDeaEd/FL9XR9LGivFYPoWbb0I5rpHkXyfPsFm2HZC/TuiU0R8u2GgF0fQzHsuffZwcMJTvoOSG6g==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "is-plain-object": "^5.0.0",
@@ -26607,6 +26739,68 @@
                 "redux": "^4.1.0"
             }
         },
+        "@types/wordpress__edit-post": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/wordpress__edit-post/-/wordpress__edit-post-7.0.2.tgz",
+            "integrity": "sha512-K3y+xM7afo8YZA4QnsrkhKUWb6TF9HQDHiG0HSGFRb7eyYynx1rpByC5vJW1AZg81OqvsAsYyzscHIbiS1jFZw==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*",
+                "@types/wordpress__components": "*",
+                "@wordpress/data": "^9.0.0",
+                "@wordpress/element": "^5.0.0"
+            },
+            "dependencies": {
+                "@wordpress/data": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.0.0.tgz",
+                    "integrity": "sha512-+FBLxCNZSGhI5b6+Bx2lE4PhmbPTCl7WqEcDByiTp4EGotJXtDaanUukxv3sI5qDrX8nKroqN8uytxIL2raHlg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/runtime": "^7.16.0",
+                        "@wordpress/compose": "^6.7.0",
+                        "@wordpress/deprecated": "^3.30.0",
+                        "@wordpress/element": "^5.7.0",
+                        "@wordpress/is-shallow-equal": "^4.30.0",
+                        "@wordpress/priority-queue": "^2.30.0",
+                        "@wordpress/private-apis": "^0.12.0",
+                        "@wordpress/redux-routine": "^4.30.0",
+                        "deepmerge": "^4.3.0",
+                        "equivalent-key-map": "^0.2.2",
+                        "is-plain-object": "^5.0.0",
+                        "is-promise": "^4.0.0",
+                        "redux": "^4.1.2",
+                        "turbo-combine-reducers": "^1.0.2",
+                        "use-memo-one": "^1.1.1"
+                    }
+                },
+                "@wordpress/element": {
+                    "version": "5.7.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.7.0.tgz",
+                    "integrity": "sha512-sztnsbrmvsiZIxXGvvKx4D/xfhKIKEylDh15Y6PqUpxMqznmnf5/+fxLc9zeVAkV/c+Yd8xp3DxUH230tCAkpQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/runtime": "^7.16.0",
+                        "@types/react": "^18.0.21",
+                        "@types/react-dom": "^18.0.6",
+                        "@wordpress/escape-html": "^2.30.0",
+                        "change-case": "^4.1.2",
+                        "is-plain-object": "^5.0.0",
+                        "react": "^18.2.0",
+                        "react-dom": "^18.2.0"
+                    }
+                },
+                "@wordpress/private-apis": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.12.0.tgz",
+                    "integrity": "sha512-x0nPVPiJA1ntL62xMCueNGuFlIDDqdfHXtk38X08tRCU+S6ILO0MZ9AGMhAl4nsWb8S6D+7t9iB9K0Y/wmDO2g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/runtime": "^7.16.0"
+                    }
+                }
+            }
+        },
         "@types/wordpress__keycodes": {
             "version": "2.3.1",
             "dev": true
@@ -27348,22 +27542,39 @@
             }
         },
         "@wordpress/compose": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.6.0.tgz",
-            "integrity": "sha512-+LsVWPf4IhL7Br3RB89m+If/6Swspu0wB2nSd28z3spHP92ndszp0Lli6rrFRRkDPWEva/b+bfxv8oDFBx3qCg==",
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.7.0.tgz",
+            "integrity": "sha512-Uas6Lc7V4vVlnfjbey9AK8Pm1w85FoSCBYenWO3jx1ZR/C9djDoQEczDqiJk1jsEGNUtNKSaS+6O4/ubQ9NkyA==",
             "requires": {
                 "@babel/runtime": "^7.16.0",
                 "@types/mousetrap": "^1.6.8",
-                "@wordpress/deprecated": "^3.29.0",
-                "@wordpress/dom": "^3.29.0",
-                "@wordpress/element": "^5.6.0",
-                "@wordpress/is-shallow-equal": "^4.29.0",
-                "@wordpress/keycodes": "^3.29.0",
-                "@wordpress/priority-queue": "^2.29.0",
+                "@wordpress/deprecated": "^3.30.0",
+                "@wordpress/dom": "^3.30.0",
+                "@wordpress/element": "^5.7.0",
+                "@wordpress/is-shallow-equal": "^4.30.0",
+                "@wordpress/keycodes": "^3.30.0",
+                "@wordpress/priority-queue": "^2.30.0",
                 "change-case": "^4.1.2",
                 "clipboard": "^2.0.8",
                 "mousetrap": "^1.6.5",
                 "use-memo-one": "^1.1.1"
+            },
+            "dependencies": {
+                "@wordpress/element": {
+                    "version": "5.7.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.7.0.tgz",
+                    "integrity": "sha512-sztnsbrmvsiZIxXGvvKx4D/xfhKIKEylDh15Y6PqUpxMqznmnf5/+fxLc9zeVAkV/c+Yd8xp3DxUH230tCAkpQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.16.0",
+                        "@types/react": "^18.0.21",
+                        "@types/react-dom": "^18.0.6",
+                        "@wordpress/escape-html": "^2.30.0",
+                        "change-case": "^4.1.2",
+                        "is-plain-object": "^5.0.0",
+                        "react": "^18.2.0",
+                        "react-dom": "^18.2.0"
+                    }
+                }
             }
         },
         "@wordpress/core-data": {
@@ -27435,21 +27646,31 @@
             }
         },
         "@wordpress/deprecated": {
-            "version": "3.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.29.0.tgz",
-            "integrity": "sha512-2rn5xhe1r8xQnmI+JRjkMDC099AoO4+KTeBmqz7zDsKoelc5ECXNUak4tj7DpAehh23DQnyBvXkl/CX6Hf9UwQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.30.0.tgz",
+            "integrity": "sha512-+Zk2wqDtvEkq9BY0SHeKHvywPn37hIsDkCyrRHChNhZYYluAzLS9mZKkFKjIuj6+dxYMINbkWcljA+HO0kdcQQ==",
             "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/hooks": "^3.29.0"
+                "@wordpress/hooks": "^3.30.0"
+            },
+            "dependencies": {
+                "@wordpress/hooks": {
+                    "version": "3.30.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.30.0.tgz",
+                    "integrity": "sha512-cvM5OWMQx0D2+wxvsTCI68LXy4cHz1Db97LliiQ+KprSBmYRG5Uy2PqtPv1sMlK8IOypKOlzmG5H5V1CwBN44A==",
+                    "requires": {
+                        "@babel/runtime": "^7.16.0"
+                    }
+                }
             }
         },
         "@wordpress/dom": {
-            "version": "3.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.29.0.tgz",
-            "integrity": "sha512-OBTbirMjAMX/2EOKjj5eCqvpb6ZYh/frxTM2vBsqcmjjn8GOqOi4MHLfX2G1XmtW47Xz1KhrENE7cTqxYDtQtw==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.30.0.tgz",
+            "integrity": "sha512-iO1SW4gr1LiuyuZf0wCaUb/N8tUprt6+nH6d8XMMJN6DCm0dmL/m0DGUYYBTLO0NtbBYCKQah8BaXz5T9qH2cA==",
             "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/deprecated": "^3.29.0"
+                "@wordpress/deprecated": "^3.30.0"
             }
         },
         "@wordpress/dom-ready": {
@@ -27618,9 +27839,9 @@
             }
         },
         "@wordpress/escape-html": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.29.0.tgz",
-            "integrity": "sha512-/zsYF2jXIm7SbLlR0hXHzJpjiSycZ/rPKXWaZRK8EUxzA30FLc7mPiwWY0pmJxi+1mq+q7t8tHhIp01Z64LOBQ==",
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.30.0.tgz",
+            "integrity": "sha512-A0FVcCPSfzCsuoLJOGCKOj3ygg6lWptugtyFcXoELG15AJ3ivfeJEeghZo77YpaWCmyCf0yTC56qbaAa2c48uw==",
             "requires": {
                 "@babel/runtime": "^7.16.0"
             }
@@ -27735,9 +27956,9 @@
             }
         },
         "@wordpress/is-shallow-equal": {
-            "version": "4.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.29.0.tgz",
-            "integrity": "sha512-aftVUNlivrXIXZT9Xepc6VYoitCX2v6RnT2j7voHSU3lrL6QcWfY4HMiIsIrBbHUCraUxkD0NrFiJ6t3kcOQlw==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.30.0.tgz",
+            "integrity": "sha512-8JxjnS7ncTkw3RJZWMG2mg0eDsip2cTpT2tR4cQte8Ol4Mumz2ByFiTJt3cFPAmqZ3XhBr4bnYurHL0ZUuRzIg==",
             "requires": {
                 "@babel/runtime": "^7.16.0"
             }
@@ -27775,13 +27996,36 @@
             }
         },
         "@wordpress/keycodes": {
-            "version": "3.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.29.0.tgz",
-            "integrity": "sha512-SZd7FSngpKhI/JjjRRuFojoTrU782ZaYSzxZyyV3ByqIzVs51sxwdjwNNswTPyD3eMTIz1SQb0U8ma0FH0epwA==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.30.0.tgz",
+            "integrity": "sha512-rDZYk/t3a/WtOi8SrfVrHP63mT5NXw13kNf3+VL/jk+hcacb6TXImFEwH0F5nLHVYpvv0fPSoFUDo5bYqwbHZQ==",
             "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/i18n": "^4.29.0",
+                "@wordpress/i18n": "^4.30.0",
                 "change-case": "^4.1.2"
+            },
+            "dependencies": {
+                "@wordpress/hooks": {
+                    "version": "3.30.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.30.0.tgz",
+                    "integrity": "sha512-cvM5OWMQx0D2+wxvsTCI68LXy4cHz1Db97LliiQ+KprSBmYRG5Uy2PqtPv1sMlK8IOypKOlzmG5H5V1CwBN44A==",
+                    "requires": {
+                        "@babel/runtime": "^7.16.0"
+                    }
+                },
+                "@wordpress/i18n": {
+                    "version": "4.30.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.30.0.tgz",
+                    "integrity": "sha512-vIntwrTBSU2MXOBlpyFntPgimHP+RW+k7/Y00BMPL+xoxPr7J7sXX/GNoYlH1BNsAo7XOi5AY5FrUnQ7ZIYdtQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.16.0",
+                        "@wordpress/hooks": "^3.30.0",
+                        "gettext-parser": "^1.3.1",
+                        "memize": "^1.1.0",
+                        "sprintf-js": "^1.1.1",
+                        "tannin": "^1.2.0"
+                    }
+                }
             }
         },
         "@wordpress/media-utils": {
@@ -27868,9 +28112,9 @@
             }
         },
         "@wordpress/priority-queue": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.29.0.tgz",
-            "integrity": "sha512-vgEQcqpF3JX3tDVQRX09yXBmbw7aBCminlWeXE/oAC9Q6iGY3BuIAUpg4J9uPdjF0mNa0zyLLh/LgiYZynhzOg==",
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.30.0.tgz",
+            "integrity": "sha512-++X/TXeBM4N4PBeLR5NeXE6wzZvvsOhfLo+/hXwcu6lkSumtw/gK7EfN9qxu0O1MRNHFEdIGdKyX8QTTjcCPGw==",
             "requires": {
                 "@babel/runtime": "^7.16.0",
                 "requestidlecallback": "^0.3.0"
@@ -27885,9 +28129,9 @@
             }
         },
         "@wordpress/redux-routine": {
-            "version": "4.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.29.0.tgz",
-            "integrity": "sha512-p4FuiNVVCtHs0NSb3W2xbTXagUVHNofX7qVlpr8mREhGk31v8gD2EhHl+M7Fkm45PFJRhoOtIHgSP3t4QBb3+Q==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.30.0.tgz",
+            "integrity": "sha512-m3DBpnCtldDeaEd/FL9XR9LGivFYPoWbb0I5rpHkXyfPsFm2HZC/TuiU0R8u2GgF0fQzHsuffZwcMJTvoOSG6g==",
             "requires": {
                 "@babel/runtime": "^7.16.0",
                 "is-plain-object": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "@trivago/prettier-plugin-sort-imports": "4.1.1",
         "@types/wordpress__block-editor": "11.5.0",
         "@types/wordpress__blocks": "12.5.0",
+        "@types/wordpress__edit-post": "^7.0.2",
         "@typescript-eslint/parser": "5.56.0",
         "@wordpress/block-editor": "11.6.0",
         "@wordpress/env": "5.14.0",

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -8,13 +8,13 @@ import { escapeHTML } from '@wordpress/escape-html';
 import { applyFilters } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { sprintf, __ } from '@wordpress/i18n';
-import { colord } from 'colord';
 import Editor from 'react-simple-code-editor';
 import { useDefaults } from '../hooks/useDefaults';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguageStore } from '../state/language';
 import { AttributesPropsAndSetter, Lang } from '../types';
 import { parseJSONArrayWithRanges } from '../util/arrayHelpers';
+import { computeLineHighlightColor } from '../util/colors';
 import { getEditorLanguage } from '../util/languages';
 import { MissingPermissionsTip } from './components/misc/MissingPermissions';
 
@@ -112,10 +112,8 @@ export const Edit = ({
             rendered,
             attributes,
         ) as string;
-        const lineHighlightColor = colord(color)
-            .saturate(0.5)
-            .alpha(0.2)
-            .toRgbString();
+        const lineHighlightColor = computeLineHighlightColor(color, attributes);
+        console.log({ color, lineHighlightColor });
         setAttributes({ codeHTML, lineHighlightColor });
     }, [
         highlighter,

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -113,7 +113,6 @@ export const Edit = ({
             attributes,
         ) as string;
         const lineHighlightColor = computeLineHighlightColor(color, attributes);
-        console.log({ color, lineHighlightColor });
         setAttributes({ codeHTML, lineHighlightColor });
     }, [
         highlighter,

--- a/src/editor/components/HeaderSelect.tsx
+++ b/src/editor/components/HeaderSelect.tsx
@@ -5,11 +5,15 @@ import { Headlights } from './headers/Headlights';
 import { HeadlightsMuted } from './headers/HeadlightsMuted';
 import { HeadlightsMutedAlt } from './headers/HeadlightsMutedAlt';
 import { SimpleString } from './headers/SimpleString';
+import { UnsupportedTheme } from './misc/Unsupported';
 
 type HeaderSelectProps = {
     attributes: Attributes;
     onClick: (slug: string) => void;
 };
+
+const unsupportedWithCssVars = ['headlightsMutedAlt'];
+
 export const HeaderSelect = ({ attributes, onClick }: HeaderSelectProps) => {
     const { headerType, ...attributesWithoutHeaderType }: Partial<Attributes> =
         attributes;
@@ -21,6 +25,7 @@ export const HeaderSelect = ({ attributes, onClick }: HeaderSelectProps) => {
         headlightsMutedAlt: __('Headlights muted alt', 'code-block-pro'),
         simpleString: __('Simple string', 'code-block-pro'),
     };
+    const isUnsupported = bgColor?.startsWith('var(');
 
     return (
         <div className="code-block-pro-editor">
@@ -61,6 +66,9 @@ export const HeaderSelect = ({ attributes, onClick }: HeaderSelectProps) => {
                             />
                         </span>
                     </button>
+                    {isUnsupported && unsupportedWithCssVars.includes(slug) && (
+                        <UnsupportedTheme />
+                    )}
                 </BaseControl>
             ))}
         </div>
@@ -68,7 +76,12 @@ export const HeaderSelect = ({ attributes, onClick }: HeaderSelectProps) => {
 };
 
 export const HeaderType = (attributes: Partial<Attributes>) => {
-    const { headerType } = attributes;
+    const { headerType, bgColor } = attributes;
+    const isACustomTheme = bgColor?.startsWith('var(');
+    if (isACustomTheme && unsupportedWithCssVars.includes(headerType ?? '')) {
+        return null;
+    }
+
     if (headerType === 'headlights') {
         return <Headlights {...attributes} />;
     }

--- a/src/editor/components/ThemeFilter.tsx
+++ b/src/editor/components/ThemeFilter.tsx
@@ -11,7 +11,11 @@ import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { useSettingsStore } from '../../state/settings';
-import { getNormalThemes, getPriorityThemes } from '../../util/themes';
+import {
+    getCustomThemes,
+    getNormalThemes,
+    getPriorityThemes,
+} from '../../util/themes';
 
 export const ThemeFilter = ({
     search,
@@ -78,14 +82,16 @@ const ThemeVisibilitySelector = ({
                             {__('Priority themes', 'code-block-pro')}
                         </h2>
                         <div className="md:grid gap-3 grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                            {priorityThemes.map(({ name, slug }) => (
-                                <ToggleControl
-                                    key={slug}
-                                    checked={!hiddenThemes.includes(slug)}
-                                    label={name}
-                                    onChange={() => toggleHiddenTheme(slug)}
-                                />
-                            ))}
+                            {[...getCustomThemes(), ...priorityThemes].map(
+                                ({ name, slug }) => (
+                                    <ToggleControl
+                                        key={slug}
+                                        checked={!hiddenThemes.includes(slug)}
+                                        label={name}
+                                        onChange={() => toggleHiddenTheme(slug)}
+                                    />
+                                ),
+                            )}
                         </div>
                     </div>
                 ) : null}

--- a/src/editor/components/ThemePreview.tsx
+++ b/src/editor/components/ThemePreview.tsx
@@ -3,7 +3,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { Theme } from 'shiki';
 import { useTheme } from '../../hooks/useTheme';
-import { Lang } from '../../types';
+import { CustomStyles, Lang } from '../../types';
 import { fontFamilyLong, maybeClamp } from '../../util/fonts';
 
 type ThemePreviewProps = {
@@ -15,6 +15,7 @@ type ThemePreviewProps = {
     lineHeight: string;
     fontFamily: string;
     clampFonts: boolean;
+    styles?: CustomStyles;
     onClick: () => void;
 };
 export const ThemePreview = ({
@@ -27,6 +28,7 @@ export const ThemePreview = ({
     lineHeight,
     fontFamily,
     clampFonts,
+    styles,
 }: ThemePreviewProps) => {
     const [inView, setInView] = useState(false);
     const { highlighter, error, loading } = useTheme({
@@ -78,14 +80,23 @@ float Q_rsqrt( float number )
         setCode(hl);
         setBg(highlighter.getBackgroundColor());
     }, [highlighter, lang, code, codeSnippet]);
-
     return (
         <button
             id={id}
             type="button"
             onClick={onClick}
             className="cbp-theme-preview p-4 px-3 border flex items-start w-full text-left outline-none cursor-pointer no-underline ring-offset-2 ring-offset-white focus:shadow-none focus:ring-wp overflow-x-auto max-h-80 overflow-y-hidden"
-            style={{ backgroundColor, minHeight: '50px' }}>
+            style={{
+                backgroundColor,
+                minHeight: '50px',
+                ...Object.entries(styles ?? {}).reduce(
+                    (acc, [key, value]) => ({
+                        ...acc,
+                        [`--shiki-${key}`]: value,
+                    }),
+                    {},
+                ),
+            }}>
             {loading || error || !inView ? (
                 <span
                     id={id}

--- a/src/editor/components/ThemeSelect.tsx
+++ b/src/editor/components/ThemeSelect.tsx
@@ -52,9 +52,9 @@ export const ThemeSelect = (props: ThemeSelectProps) => {
                     )}
                 </BaseControl>
             ) : priorityThemes?.length > 0 ? null : (
-                <div className="font-semibold text-base mb-4">
+                <div className="text-sm mb-4">
                     <ExternalLink href="https://github.com/KevinBatdorf/code-block-pro/discussions/168">
-                        {__('Looking for light/dark mode?', 'code-block-pro')}
+                        {__('Need both light and dark mode?', 'code-block-pro')}
                     </ExternalLink>
                 </div>
             )}

--- a/src/editor/components/ThemeSelect.tsx
+++ b/src/editor/components/ThemeSelect.tsx
@@ -4,7 +4,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { Theme } from 'shiki';
 import defaultThemes from '../../defaultThemes.json';
 import { useSettingsStore } from '../../state/settings';
-import { Lang } from '../../types';
+import { CustomStyles, HelpUrl, Lang, ThemeOption } from '../../types';
 import { getPriorityThemes } from '../../util/themes';
 import { ThemePreview } from '../components/ThemePreview';
 
@@ -24,12 +24,15 @@ export const ThemeSelect = (props: ThemeSelectProps) => {
     const themes = applyFilters(
         'blocks.codeBlockPro.themes',
         defaultThemes,
-    ) as Record<string, { name: string; priority?: boolean }>;
+    ) as ThemeOption;
     const themesSorted = Object.entries(themes)
         .filter(([slug]) => !hiddenThemes.includes(slug))
         .filter(([slug]) => slug.includes(props.search.toLocaleLowerCase()))
-        .map(([slug, { name, priority }]) => ({ name, slug, priority }))
-        .sort((a, b) => (a.priority === b.priority ? 0 : a.priority ? -1 : 1));
+        .map(([slug, data]) => ({ slug, ...data }))
+        // Put priority themes at the top
+        .sort((a, b) => (a.priority === b.priority ? 0 : a.priority ? -1 : 1))
+        // then put custom themes above that
+        .sort((a, b) => (a.custom === b.custom ? 0 : a.custom ? -1 : 1));
 
     const priorityThemes = getPriorityThemes();
 
@@ -48,9 +51,15 @@ export const ThemeSelect = (props: ThemeSelectProps) => {
                         </div>
                     )}
                 </BaseControl>
-            ) : null}
-            {themesSorted.slice(0, 9).map(({ name, slug }) => (
-                <ThemeItem key={slug} slug={slug} name={name} {...props} />
+            ) : priorityThemes?.length > 0 ? null : (
+                <div className="font-semibold text-base mb-4">
+                    <ExternalLink href="https://github.com/KevinBatdorf/code-block-pro/discussions/168">
+                        {__('Looking for light/dark mode?', 'code-block-pro')}
+                    </ExternalLink>
+                </div>
+            )}
+            {themesSorted.slice(0, 9).map((data) => (
+                <ThemeItem key={data.slug} {...data} {...props} />
             ))}
             {props.search?.length > 0 ? null : (
                 <BaseControl id="add-on-themes">
@@ -66,8 +75,8 @@ export const ThemeSelect = (props: ThemeSelectProps) => {
                     )}
                 </BaseControl>
             )}
-            {themesSorted.slice(9).map(({ name, slug }) => (
-                <ThemeItem key={slug} slug={slug} name={name} {...props} />
+            {themesSorted.slice(9).map((data) => (
+                <ThemeItem key={data.slug} {...data} {...props} />
             ))}
             {props.search?.length > 0 ? null : (
                 <BaseControl id="add-on-themes">
@@ -98,7 +107,14 @@ const ThemeItem = ({
     fontFamily,
     clampFonts,
     onClick,
-}: { slug: string; name: string } & ThemeSelectProps) => (
+    styles,
+    helpUrl,
+}: {
+    slug: string;
+    name: string;
+    styles?: CustomStyles;
+    helpUrl?: HelpUrl;
+} & ThemeSelectProps) => (
     <BaseControl
         id={`code-block-pro-theme-${slug}`}
         label={
@@ -106,18 +122,28 @@ const ThemeItem = ({
                 ? sprintf(__('%s (current)', 'code-block-pro'), name)
                 : name
         }>
-        <ThemePreview
-            id={`code-block-pro-theme-${slug}`}
-            theme={slug as Theme}
-            lang={language}
-            fontSize={fontSize}
-            lineHeight={lineHeight}
-            fontFamily={fontFamily}
-            clampFonts={clampFonts}
-            onClick={() => {
-                onClick(slug as Theme);
-            }}
-            code={code}
-        />
+        <>
+            <ThemePreview
+                id={`code-block-pro-theme-${slug}`}
+                theme={slug as Theme}
+                lang={language}
+                fontSize={fontSize}
+                lineHeight={lineHeight}
+                fontFamily={fontFamily}
+                clampFonts={clampFonts}
+                styles={styles}
+                onClick={() => {
+                    onClick(slug as Theme);
+                }}
+                code={code}
+            />
+            {helpUrl?.url ? (
+                <div className="mt-2">
+                    <ExternalLink href={helpUrl.url}>
+                        {helpUrl?.text || __('Read more', 'code-block-pro')}
+                    </ExternalLink>
+                </div>
+            ) : null}
+        </>
     </BaseControl>
 );

--- a/src/editor/components/footers/SimpleStringEnd.tsx
+++ b/src/editor/components/footers/SimpleStringEnd.tsx
@@ -11,9 +11,12 @@ export const SimpleStringEnd = ({
     footerLinkTarget,
     disablePadding,
 }: Partial<Attributes>) => {
-    const bgC = colord(bgColor as AnyColor);
     const textC = colord(textColor as AnyColor);
-    const text = textC.isDark() ? textC.lighten(0.05) : textC.darken(0.05);
+    const text = textColor?.startsWith('var(')
+        ? textColor
+        : textC.isDark()
+        ? textC.lighten(0.05).toHex()
+        : textC.darken(0.05).toHex();
     return (
         <span
             style={{
@@ -22,15 +25,15 @@ export const SimpleStringEnd = ({
                 padding: disablePadding ? '10px 0 0 0' : '10px',
                 width: '100%',
                 justifyContent: 'flex-end',
-                backgroundColor: bgC.toHex(),
-                color: text.toHex(),
+                backgroundColor: bgColor,
+                color: text,
                 fontSize: '12px',
                 lineHeight: '1',
                 position: 'relative',
             }}>
             <Inner
                 text={footerString || languages[language as Lang]}
-                color={text.toHex()}
+                color={text}
                 link={footerLink}
                 linkTarget={footerLinkTarget}
             />

--- a/src/editor/components/footers/SimpleStringStart.tsx
+++ b/src/editor/components/footers/SimpleStringStart.tsx
@@ -11,9 +11,12 @@ export const SimpleStringStart = ({
     footerLinkTarget,
     disablePadding,
 }: Partial<Attributes>) => {
-    const bgC = colord(bgColor as AnyColor);
     const textC = colord(textColor as AnyColor);
-    const text = textC.isDark() ? textC.lighten(0.05) : textC.darken(0.05);
+    const text = textColor?.startsWith('var(')
+        ? textColor
+        : textC.isDark()
+        ? textC.lighten(0.05).toHex()
+        : textC.darken(0.05).toHex();
     return (
         <span
             style={{
@@ -22,15 +25,15 @@ export const SimpleStringStart = ({
                 padding: disablePadding ? '10px 0 0 0' : '10px',
                 width: '100%',
                 justifyContent: 'flex-start',
-                backgroundColor: bgC.toHex(),
-                color: text.toHex(),
+                backgroundColor: bgColor,
+                color: text,
                 fontSize: '12px',
                 lineHeight: '1',
                 position: 'relative',
             }}>
             <Inner
                 text={footerString || languages[language as Lang]}
-                color={text.toHex()}
+                color={text}
                 link={footerLink}
                 linkTarget={footerLinkTarget}
             />

--- a/src/editor/components/headers/Headlights.tsx
+++ b/src/editor/components/headers/Headlights.tsx
@@ -1,6 +1,7 @@
 import { Attributes } from '../../../types';
+import { findBackgroundColor } from '../../../util/colors';
 
-export const Headlights = ({ bgColor }: Partial<Attributes>) => (
+export const Headlights = (attributes: Partial<Attributes>) => (
     <span
         style={{
             display: 'block',
@@ -8,7 +9,7 @@ export const Headlights = ({ bgColor }: Partial<Attributes>) => (
             marginBottom: '-1px',
             width: '100%',
             textAlign: 'left',
-            backgroundColor: bgColor,
+            backgroundColor: findBackgroundColor(attributes),
         }}>
         <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/editor/components/headers/HeadlightsMuted.tsx
+++ b/src/editor/components/headers/HeadlightsMuted.tsx
@@ -1,59 +1,60 @@
 import { colord, AnyColor } from 'colord';
 import { Attributes } from '../../../types';
+import { findBackgroundColor } from '../../../util/colors';
 
-export const HeadlightsMuted = ({
-    textColor,
-    bgColor,
-}: Partial<Attributes>) => (
-    <span
-        style={{
-            display: 'block',
-            padding: '16px 0 0 16px',
-            marginBottom: '-1px',
-            width: '100%',
-            textAlign: 'left',
-            backgroundColor: bgColor,
-        }}>
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width={54}
-            height={14}
-            viewBox="0 0 54 14">
-            <g fill="none" fillRule="evenodd" transform="translate(1 1)">
-                <circle
-                    cx="6"
-                    cy="6"
-                    r="6"
-                    fill={colord(textColor as AnyColor)
-                        .alpha(0.2)
-                        .toHex()}
-                    stroke={colord(textColor as AnyColor)
-                        .alpha(0.3)
-                        .toHex()}
-                    strokeWidth=".5"></circle>
-                <circle
-                    cx="26"
-                    cy="6"
-                    r="6"
-                    fill={colord(textColor as AnyColor)
-                        .alpha(0.2)
-                        .toHex()}
-                    stroke={colord(textColor as AnyColor)
-                        .alpha(0.3)
-                        .toHex()}
-                    strokeWidth=".5"></circle>
-                <circle
-                    cx="46"
-                    cy="6"
-                    r="6"
-                    fill={colord(textColor as AnyColor)
-                        .alpha(0.2)
-                        .toHex()}
-                    stroke={colord(textColor as AnyColor)
-                        .alpha(0.3)
-                        .toHex()}
-                    strokeWidth=".5"></circle>
-            </g>
-        </svg>
-    </span>
-);
+export const HeadlightsMuted = (attributes: Partial<Attributes>) => {
+    const { textColor } = attributes;
+    return (
+        <span
+            style={{
+                display: 'block',
+                padding: '16px 0 0 16px',
+                marginBottom: '-1px',
+                width: '100%',
+                textAlign: 'left',
+                backgroundColor: findBackgroundColor(attributes),
+            }}>
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width={54}
+                height={14}
+                viewBox="0 0 54 14">
+                <g fill="none" fillRule="evenodd" transform="translate(1 1)">
+                    <circle
+                        cx="6"
+                        cy="6"
+                        r="6"
+                        fill={colord(textColor as AnyColor)
+                            .alpha(0.2)
+                            .toHex()}
+                        stroke={colord(textColor as AnyColor)
+                            .alpha(0.3)
+                            .toHex()}
+                        strokeWidth=".5"></circle>
+                    <circle
+                        cx="26"
+                        cy="6"
+                        r="6"
+                        fill={colord(textColor as AnyColor)
+                            .alpha(0.2)
+                            .toHex()}
+                        stroke={colord(textColor as AnyColor)
+                            .alpha(0.3)
+                            .toHex()}
+                        strokeWidth=".5"></circle>
+                    <circle
+                        cx="46"
+                        cy="6"
+                        r="6"
+                        fill={colord(textColor as AnyColor)
+                            .alpha(0.2)
+                            .toHex()}
+                        stroke={colord(textColor as AnyColor)
+                            .alpha(0.3)
+                            .toHex()}
+                        strokeWidth=".5"></circle>
+                </g>
+            </svg>
+        </span>
+    );
+};

--- a/src/editor/components/headers/SimpleString.tsx
+++ b/src/editor/components/headers/SimpleString.tsx
@@ -9,9 +9,20 @@ export const SimpleString = ({
     headerString,
 }: Partial<Attributes>) => {
     const bgC = colord(bgColor as AnyColor);
-    const bg = bgC.isDark() ? bgC.lighten(0.05) : bgC.darken(0.05);
+    let bg = bgC.isDark()
+        ? bgC.lighten(0.05).toHex()
+        : bgC.darken(0.05).toHex();
     const textC = colord(textColor as AnyColor);
-    const text = textC.isDark() ? textC.lighten(0.05) : textC.darken(0.05);
+    let text = textC.isDark()
+        ? textC.lighten(0.05).toHex()
+        : textC.darken(0.05).toHex();
+
+    if (bgColor?.startsWith('var(')) {
+        bg = bgColor;
+    }
+    if (textColor?.startsWith('var(')) {
+        text = textColor;
+    }
     return (
         <span
             style={{
@@ -21,8 +32,8 @@ export const SimpleString = ({
                 marginBottom: '-2px',
                 width: '100%',
                 textAlign: 'left',
-                backgroundColor: bg.toHex(),
-                color: text.toHex(),
+                backgroundColor: bg,
+                color: text,
             }}>
             {headerString || languages[language as Lang]}
         </span>

--- a/src/editor/components/misc/Unsupported.tsx
+++ b/src/editor/components/misc/Unsupported.tsx
@@ -1,0 +1,7 @@
+import { __ } from '@wordpress/i18n';
+
+export const UnsupportedTheme = () => (
+    <div className="block w-full h-8 pt-2">
+        {__('Not supported with this theme', 'code-block-pro')}
+    </div>
+);

--- a/src/editor/controls/Toolbar.tsx
+++ b/src/editor/controls/Toolbar.tsx
@@ -9,12 +9,14 @@ import {
     MenuGroup,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore-next-line - store is not typed
 import { store as editPostStore } from '@wordpress/edit-post';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import defaultThemes from '../../defaultThemes.json';
 import { useLanguage } from '../../hooks/useLanguage';
-import { AttributesPropsAndSetter, Lang } from '../../types';
+import { AttributesPropsAndSetter, Lang, ThemeOption } from '../../types';
 import { languages } from '../../util/languages';
 
 export const ToolbarControls = ({
@@ -26,7 +28,7 @@ export const ToolbarControls = ({
     const themes = applyFilters(
         'blocks.codeBlockPro.themes',
         defaultThemes,
-    ) as Record<string, { name: string; priority?: boolean }>;
+    ) as ThemeOption;
 
     const { openGeneralSidebar } = useDispatch(editPostStore);
 
@@ -66,11 +68,20 @@ export const ToolbarControls = ({
                         )}>
                         <span className="flex mx-2">
                             <span
-                                style={{ backgroundColor: bgColor }}
+                                style={{
+                                    backgroundColor:
+                                        themes[theme]?.styles?.[
+                                            'color-background'
+                                        ] ?? bgColor,
+                                }}
                                 className="w-3 h-3 border border-gray-400 border-solid border-1 rounded-full inline-block"
                             />
                             <span
-                                style={{ backgroundColor: textColor }}
+                                style={{
+                                    backgroundColor:
+                                        themes[theme]?.styles?.['color-text'] ??
+                                        textColor,
+                                }}
                                 className="w-3 h-3 border border-gray-400 border-solid border-1 rounded-full inline-block transform -translate-x-1"
                             />
                         </span>

--- a/src/front/BlockOutput.tsx
+++ b/src/front/BlockOutput.tsx
@@ -6,7 +6,7 @@ import { FooterType } from '../editor/components/FooterSelect';
 import { HeaderType } from '../editor/components/HeaderSelect';
 import { SeeMoreType } from '../editor/components/SeeMoreSelect';
 import { Attributes, ThemeOption } from '../types';
-import { computeLineNumbersColor } from '../util/colors';
+import { findLineNumberColor } from '../util/colors';
 import { fontFamilyLong, maybeClamp } from '../util/fonts';
 import { CopyButton } from './CopyButton';
 import './style.css';
@@ -41,7 +41,7 @@ export const BlockOutput = ({ attributes }: { attributes: Attributes }) => {
                     // Tiny check to avoid block invalidation error
                     fontFamily: fontFamilyLong(attributes.fontFamily),
                     '--cbp-line-number-color': attributes?.lineNumbers
-                        ? computeLineNumbersColor(attributes)
+                        ? findLineNumberColor(attributes)
                         : undefined,
                     '--cbp-line-number-start':
                         Number(attributes?.startingLineNumber) > 1

--- a/src/front/BlockOutput.tsx
+++ b/src/front/BlockOutput.tsx
@@ -1,69 +1,86 @@
 import { RichText, useBlockProps as blockProps } from '@wordpress/block-editor';
 import { applyFilters } from '@wordpress/hooks';
 import classNames from 'classnames';
+import defaultThemes from '../defaultThemes.json';
 import { FooterType } from '../editor/components/FooterSelect';
 import { HeaderType } from '../editor/components/HeaderSelect';
 import { SeeMoreType } from '../editor/components/SeeMoreSelect';
-import { Attributes } from '../types';
+import { Attributes, ThemeOption } from '../types';
 import { fontFamilyLong, maybeClamp } from '../util/fonts';
 import { CopyButton } from './CopyButton';
 import './style.css';
 
-export const BlockOutput = ({ attributes }: { attributes: Attributes }) => (
-    <div
-        {...blockProps.save({
-            className: classNames({
-                'padding-disabled': attributes.disablePadding,
-                'padding-bottom-disabled':
-                    attributes?.footerType && attributes?.footerType !== 'none',
-                'cbp-has-line-numbers': attributes.lineNumbers,
-                'cbp-blur-enabled': attributes.enableBlurring,
-                'cbp-unblur-on-hover': attributes.removeBlurOnHover,
-            }),
-        })}
-        data-code-block-pro-font-family={attributes.fontFamily}
-        style={
-            {
-                fontSize: maybeClamp(
-                    attributes.fontSize,
-                    attributes.clampFonts,
-                ),
-                // Tiny check to avoid block invalidation error
-                fontFamily: fontFamilyLong(attributes.fontFamily),
-                '--cbp-line-number-color': attributes?.lineNumbers
-                    ? attributes.textColor
-                    : undefined,
-                '--cbp-line-number-start':
-                    Number(attributes?.startingLineNumber) > 1
-                        ? attributes.startingLineNumber
+export const BlockOutput = ({ attributes }: { attributes: Attributes }) => {
+    // To add custom styles
+    const themes = applyFilters(
+        'blocks.codeBlockPro.themes',
+        defaultThemes,
+    ) as ThemeOption;
+    const styles = themes[attributes.theme]?.styles;
+    return (
+        <div
+            {...blockProps.save({
+                className: classNames({
+                    'padding-disabled': attributes.disablePadding,
+                    'padding-bottom-disabled':
+                        attributes?.footerType &&
+                        attributes?.footerType !== 'none',
+                    'cbp-has-line-numbers': attributes.lineNumbers,
+                    'cbp-blur-enabled': attributes.enableBlurring,
+                    'cbp-unblur-on-hover': attributes.removeBlurOnHover,
+                }),
+            })}
+            data-code-block-pro-font-family={attributes.fontFamily}
+            style={
+                {
+                    fontSize: maybeClamp(
+                        attributes.fontSize,
+                        attributes.clampFonts,
+                    ),
+                    // Tiny check to avoid block invalidation error
+                    fontFamily: fontFamilyLong(attributes.fontFamily),
+                    '--cbp-line-number-color': attributes?.lineNumbers
+                        ? attributes.textColor
                         : undefined,
-                '--cbp-line-number-width': attributes.lineNumbersWidth
-                    ? `${attributes.lineNumbersWidth}px`
-                    : undefined,
-                '--cbp-line-highlight-color': attributes?.enableHighlighting
-                    ? attributes.lineHighlightColor
-                    : undefined,
-                lineHeight: maybeClamp(
-                    attributes.lineHeight,
-                    attributes.clampFonts,
-                ),
-                ...(applyFilters(
-                    'blocks.codeBlockPro.additionalOutputAttributes',
-                    {},
-                    attributes,
-                ) as object),
-            } as React.CSSProperties
-        }>
-        {attributes.code?.length > 0 ? (
-            <>
-                <HeaderType {...attributes} />
-                {attributes.copyButton && (
-                    <CopyButton attributes={attributes} />
-                )}
-                <RichText.Content value={attributes.codeHTML} />
-                <FooterType {...attributes} />
-                <SeeMoreType {...attributes} />
-            </>
-        ) : null}
-    </div>
-);
+                    '--cbp-line-number-start':
+                        Number(attributes?.startingLineNumber) > 1
+                            ? attributes.startingLineNumber
+                            : undefined,
+                    '--cbp-line-number-width': attributes.lineNumbersWidth
+                        ? `${attributes.lineNumbersWidth}px`
+                        : undefined,
+                    '--cbp-line-highlight-color': attributes?.enableHighlighting
+                        ? attributes.lineHighlightColor
+                        : undefined,
+                    lineHeight: maybeClamp(
+                        attributes.lineHeight,
+                        attributes.clampFonts,
+                    ),
+                    ...Object.entries(styles ?? {}).reduce(
+                        (acc, [key, value]) => ({
+                            ...acc,
+                            [`--shiki-${key}`]: value,
+                        }),
+                        {},
+                    ),
+                    ...(applyFilters(
+                        'blocks.codeBlockPro.additionalOutputAttributes',
+                        {},
+                        attributes,
+                    ) as object),
+                } as React.CSSProperties
+            }>
+            {attributes.code?.length > 0 ? (
+                <>
+                    <HeaderType {...attributes} />
+                    {attributes.copyButton && (
+                        <CopyButton attributes={attributes} />
+                    )}
+                    <RichText.Content value={attributes.codeHTML} />
+                    <FooterType {...attributes} />
+                    <SeeMoreType {...attributes} />
+                </>
+            ) : null}
+        </div>
+    );
+};

--- a/src/front/BlockOutput.tsx
+++ b/src/front/BlockOutput.tsx
@@ -6,6 +6,7 @@ import { FooterType } from '../editor/components/FooterSelect';
 import { HeaderType } from '../editor/components/HeaderSelect';
 import { SeeMoreType } from '../editor/components/SeeMoreSelect';
 import { Attributes, ThemeOption } from '../types';
+import { computeLineNumbersColor } from '../util/colors';
 import { fontFamilyLong, maybeClamp } from '../util/fonts';
 import { CopyButton } from './CopyButton';
 import './style.css';
@@ -40,7 +41,7 @@ export const BlockOutput = ({ attributes }: { attributes: Attributes }) => {
                     // Tiny check to avoid block invalidation error
                     fontFamily: fontFamilyLong(attributes.fontFamily),
                     '--cbp-line-number-color': attributes?.lineNumbers
-                        ? attributes.textColor
+                        ? computeLineNumbersColor(attributes)
                         : undefined,
                     '--cbp-line-number-start':
                         Number(attributes?.startingLineNumber) > 1

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -3,10 +3,14 @@ import { applyFilters } from '@wordpress/hooks';
 import { getHighlighter, setCDN, Theme, setWasm } from 'shiki';
 import useSWRImmutable from 'swr/immutable';
 import defaultThemes from '../defaultThemes.json';
-import { Lang } from '../types';
+import { Lang, ThemeOption } from '../types';
 import { getEditorLanguage } from '../util/languages';
 
-type Params = { theme: Theme; lang: Lang | 'ansi'; ready?: boolean };
+type Params = {
+    theme: Theme;
+    lang: Lang | 'ansi';
+    ready?: boolean;
+};
 
 const fetcher = ({ theme, lang, ready }: Params) => {
     if (!ready) throw new Error();
@@ -32,6 +36,10 @@ let once = false;
 
 export const useTheme = ({ theme, lang, ready = true }: Params) => {
     const [wasmLoaded, setWasmFileLoaded] = useState(false);
+    const themes = applyFilters(
+        'blocks.codeBlockPro.themes',
+        defaultThemes,
+    ) as ThemeOption;
     if (!once) {
         once = true;
         const assetDir = window.codeBlockPro?.pluginUrl + 'build/shiki/';
@@ -39,6 +47,7 @@ export const useTheme = ({ theme, lang, ready = true }: Params) => {
             applyFilters('blocks.codeBlockPro.assetDir', assetDir) as string,
         );
     }
+    if (themes[theme]?.custom) theme = 'css-variables';
     const { data: highlighter, error } = useSWRImmutable(
         { theme, lang, ready: ready && wasmLoaded },
         fetcher,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { addFilter, applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import blockConfig from './block.json';
+import defaultThemes from './defaultThemes.json';
 import { Edit } from './editor/Edit';
 import { BlockFilter } from './editor/components/BlockFilter';
 import { FooterType } from './editor/components/FooterSelect';
@@ -15,7 +16,7 @@ import './editor/editor.css';
 import { BlockOutput } from './front/BlockOutput';
 import { CopyButton } from './front/CopyButton';
 import { blockIcon } from './icons';
-import { Attributes, Lang } from './types';
+import { Attributes, Lang, ThemeOption } from './types';
 import { fontFamilyLong, maybeClamp } from './util/fonts';
 import { getMainAlias } from './util/languages';
 
@@ -72,6 +73,13 @@ registerBlockType<Attributes>(blockConfig.name, {
         // Restricts users without unfiltered HTML access
         const hasPermission = window.codeBlockPro.canSaveHtml;
         setAttributes = hasPermission ? setAttributes : () => undefined;
+
+        // To add custom styles
+        const themes = applyFilters(
+            'blocks.codeBlockPro.themes',
+            defaultThemes,
+        ) as ThemeOption;
+        const styles = themes[attributes.theme]?.styles;
         return (
             <>
                 <SidebarControls
@@ -121,6 +129,13 @@ registerBlockType<Attributes>(blockConfig.name, {
                             lineHeight: maybeClamp(
                                 attributes.lineHeight,
                                 attributes.clampFonts,
+                            ),
+                            ...Object.entries(styles ?? {}).reduce(
+                                (acc, [key, value]) => ({
+                                    ...acc,
+                                    [`--shiki-${key}`]: value,
+                                }),
+                                {},
                             ),
                             ...(applyFilters(
                                 'blocks.codeBlockPro.additionalEditorAttributes',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import { BlockOutput } from './front/BlockOutput';
 import { CopyButton } from './front/CopyButton';
 import { blockIcon } from './icons';
 import { Attributes, Lang, ThemeOption } from './types';
+import { computeLineNumbersColor } from './util/colors';
 import { fontFamilyLong, maybeClamp } from './util/fonts';
 import { getMainAlias } from './util/languages';
 
@@ -108,7 +109,7 @@ registerBlockType<Attributes>(blockConfig.name, {
                                 attributes.clampFonts,
                             ),
                             '--cbp-line-number-color': attributes?.lineNumbers
-                                ? attributes.textColor
+                                ? computeLineNumbersColor(attributes)
                                 : undefined,
                             '--cbp-line-number-start':
                                 Number(attributes?.startingLineNumber) > 1

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,7 @@ import { BlockOutput } from './front/BlockOutput';
 import { CopyButton } from './front/CopyButton';
 import { blockIcon } from './icons';
 import { Attributes, Lang, ThemeOption } from './types';
-import { computeLineNumbersColor } from './util/colors';
+import { findLineNumberColor } from './util/colors';
 import { fontFamilyLong, maybeClamp } from './util/fonts';
 import { getMainAlias } from './util/languages';
 
@@ -109,7 +109,7 @@ registerBlockType<Attributes>(blockConfig.name, {
                                 attributes.clampFonts,
                             ),
                             '--cbp-line-number-color': attributes?.lineNumbers
-                                ? computeLineNumbersColor(attributes)
+                                ? findLineNumberColor(attributes)
                                 : undefined,
                             '--cbp-line-number-start':
                                 Number(attributes?.startingLineNumber) > 1

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,8 @@ export type CustomStyles = {
     'token-string-expression'?: string; // --shiki-token-string-expression
     'token-punctuation'?: string; // --shiki-token-punctuation
     'token-link'?: string; // --shiki-token-link
+    'line-background'?: string; // custom for this app
+    'line-number-color'?: string; // custom for this app
 };
 export type HelpUrl = {
     text: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,3 +54,32 @@ declare global {
         };
     }
 }
+
+export type CustomStyles = {
+    'color-text'?: string; // --shiki-color-text
+    'color-background'?: string; // --shiki-color-background
+    'token-constant'?: string; // --shiki-token-constant
+    'token-string'?: string; // --shiki-token-string
+    'token-comment'?: string; // --shiki-token-comment
+    'token-keyword'?: string; // --shiki-token-keyword
+    'token-parameter'?: string; // --shiki-token-parameter
+    'token-function'?: string; // --shiki-token-function
+    'token-string-expression'?: string; // --shiki-token-string-expression
+    'token-punctuation'?: string; // --shiki-token-punctuation
+    'token-link'?: string; // --shiki-token-link
+};
+export type HelpUrl = {
+    text: string;
+    url: string;
+};
+
+export type ThemeOption = Record<
+    string,
+    {
+        name: string;
+        priority?: boolean;
+        custom?: boolean;
+        styles?: CustomStyles;
+        helpUrl?: HelpUrl;
+    }
+>;

--- a/src/util/colors.ts
+++ b/src/util/colors.ts
@@ -36,7 +36,7 @@ export const computeLineHighlightColor = (
     return colord(color).saturate(0.5).alpha(0.2).toRgbString();
 };
 
-export const computeLineNumbersColor = (attributes: Attributes) => {
+export const findLineNumberColor = (attributes: Attributes) => {
     const themes = applyFilters(
         'blocks.codeBlockPro.themes',
         defaultThemes,
@@ -46,4 +46,19 @@ export const computeLineNumbersColor = (attributes: Attributes) => {
         return themes?.[attributes?.theme]?.styles?.['line-number-color'];
     }
     return attributes.textColor;
+};
+
+export const findBackgroundColor = (attributes: Partial<Attributes>) => {
+    const themes = applyFilters(
+        'blocks.codeBlockPro.themes',
+        defaultThemes,
+    ) as ThemeOption;
+    // set in the theme, use that
+    if (
+        attributes?.theme &&
+        themes?.[attributes?.theme]?.styles?.['color-background']
+    ) {
+        return themes?.[attributes?.theme]?.styles?.['color-background'];
+    }
+    return attributes.bgColor;
 };

--- a/src/util/colors.ts
+++ b/src/util/colors.ts
@@ -1,0 +1,50 @@
+import { applyFilters } from '@wordpress/hooks';
+import { colord, extend } from 'colord';
+import namesPlugin from 'colord/plugins/names';
+import defaultThemes from '../defaultThemes.json';
+import { Attributes, ThemeOption } from '../types';
+
+extend([namesPlugin]);
+
+export const computeLineHighlightColor = (
+    color: string,
+    attributes: Attributes,
+) => {
+    const themes = applyFilters(
+        'blocks.codeBlockPro.themes',
+        defaultThemes,
+    ) as ThemeOption;
+    // set in the theme, use that
+    if (themes?.[attributes.theme]?.styles?.['line-background']) {
+        return themes?.[attributes?.theme]?.styles?.['line-background'];
+    }
+    // If not set in the theme, but a variable, attempt to compute it
+    // but fallback to a known default
+    if (color.startsWith('var')) {
+        const doc = document.documentElement;
+        const maybeColor = getComputedStyle(doc)
+            .getPropertyValue(
+                // extract from inside var()
+                color.replace(/^var\((--[\w-]+)\)$/, '$1'),
+            )
+            .trim();
+        const computed =
+            maybeColor || getComputedStyle(doc).getPropertyValue('--cbp-text');
+        console.log({ maybeColor, computed });
+        return colord(computed).saturate(0.5).alpha(0.2).toRgbString();
+    }
+
+    return colord(color).saturate(0.5).alpha(0.2).toRgbString();
+};
+
+export const computeLineNumbersColor = (attributes: Attributes) => {
+    const themes = applyFilters(
+        'blocks.codeBlockPro.themes',
+        defaultThemes,
+    ) as ThemeOption;
+    // set in the theme, use that
+    if (themes?.[attributes.theme]?.styles?.['line-number-color']) {
+        return themes?.[attributes?.theme]?.styles?.['line-number-color'];
+    }
+    return attributes.textColor;
+};

--- a/src/util/colors.ts
+++ b/src/util/colors.ts
@@ -30,7 +30,6 @@ export const computeLineHighlightColor = (
             .trim();
         const computed =
             maybeColor || getComputedStyle(doc).getPropertyValue('--cbp-text');
-        console.log({ maybeColor, computed });
         return colord(computed).saturate(0.5).alpha(0.2).toRgbString();
     }
 

--- a/src/util/themes.ts
+++ b/src/util/themes.ts
@@ -4,17 +4,21 @@ import defaultThemes from '../defaultThemes.json';
 const themes = () =>
     applyFilters('blocks.codeBlockPro.themes', defaultThemes) as Record<
         string,
-        { name: string; priority?: boolean }
+        { name: string; priority?: boolean; custom?: boolean }
     >;
 
 const themesNormalized = () =>
-    Object.entries(themes()).map(([slug, { name, priority }]) => ({
+    Object.entries(themes()).map(([slug, { name, priority, custom }]) => ({
         name,
         slug,
         priority,
+        custom,
     }));
 export const getPriorityThemes = () =>
     themesNormalized().filter(({ priority }) => priority);
 
 export const getNormalThemes = () =>
-    themesNormalized().filter(({ priority }) => !priority);
+    themesNormalized().filter(({ priority, custom }) => !priority && !custom);
+
+export const getCustomThemes = () =>
+    themesNormalized().filter(({ custom }) => custom);


### PR DESCRIPTION
This PR adds support for custom styles. You can add your own via a filter or otherwise buy the [theme pack](https://code-block-pro.com/themes).

This opens up using css variables for light/dark mode, etc. See here: https://github.com/KevinBatdorf/code-block-pro/discussions/168