### PR TITLE
Fix Wolfram language bug

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -266,6 +266,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Tweak: Removes the filtering of bash and zsh filtering
 - Fix: Better language sorting (by label instead of key)
 - Fix: Fix typo in Wolfram language key
 

--- a/readme.txt
+++ b/readme.txt
@@ -266,6 +266,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Fix: Better language sorting (by label instead of key)
+- Fix: Fix typo in Wolfram language key
+
 = 1.16.0 - 2023-04-30 =
 - Feature: Added new language grammars: GD Script, GD Resource, GD Shader, GLSL, Http, Jison, JSON5, Kusto (kql), Protocol Buffers (.proto), Windows Registry (.reg), V, WGSL, and Wolfram
 - Tweak: Removed toolbar language select and added functionality to focus on the sidebar setting

--- a/src/defaultLanguages.json
+++ b/src/defaultLanguages.json
@@ -190,7 +190,7 @@
     "wenyan": "Wenyan",
     "文言": "Wenyan",
     "wgsl": "WGSL",
-    "wolframe": "Wolfram",
+    "wolfram": "Wolfram",
     "xml": "XML",
     "xsl": "XSL",
     "yaml": "YAML",

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -42,6 +42,9 @@ export const SidebarControls = ({
     const { updateThemeHistory } = useThemeStore();
     const { setPreviousSettings, bringAttentionToPanel } = useGlobalStore();
     const { headerType, footerType } = attributes;
+    const languagesSorted = new Map(
+        Object.entries(languages).sort((a, b) => a[1].localeCompare(b[1])),
+    );
 
     const footersNeedingLinks = ['simpleStringEnd', 'simpleStringStart'];
 
@@ -83,7 +86,7 @@ export const SidebarControls = ({
                                       )
                                     : null
                             }
-                            options={Object.entries(languages).map(
+                            options={[...languagesSorted.entries()].map(
                                 ([value, label]) => ({
                                     label: label.replace(
                                         'ANSI',

--- a/src/util/languages.ts
+++ b/src/util/languages.ts
@@ -69,7 +69,6 @@ export const languages = removeAliases(defaultLanguages);
 
 /** Get the language shown in the editor, which could differ from the front */
 export const getEditorLanguage = (language: string): LangShiki => {
-    console.log(language);
     if (language === 'ansi') return 'shellscript';
     return language as LangShiki;
 };

--- a/src/util/languages.ts
+++ b/src/util/languages.ts
@@ -19,6 +19,7 @@ export const codeAliases = {
     java: ['javafx'],
     javascript: ['jscript', 'js'],
     jssm: ['fsl'],
+    kusto: ['kql'],
     make: ['makefile'],
     markdown: ['md'],
     matlab: ['matlabkey'],
@@ -31,7 +32,7 @@ export const codeAliases = {
     ruby: ['rb'],
     rust: ['rs'],
     shaderlab: ['shader'],
-    shellscript: ['shell', 'bash', 'sh', 'zsh'],
+    shellscript: ['shell', 'sh', 'zsh'],
     stylus: ['styl'],
     typescript: ['ts'],
     vb: ['cmd'],
@@ -68,6 +69,7 @@ export const languages = removeAliases(defaultLanguages);
 
 /** Get the language shown in the editor, which could differ from the front */
 export const getEditorLanguage = (language: string): LangShiki => {
+    console.log(language);
     if (language === 'ansi') return 'shellscript';
     return language as LangShiki;
 };

--- a/src/util/languages.ts
+++ b/src/util/languages.ts
@@ -32,7 +32,7 @@ export const codeAliases = {
     ruby: ['rb'],
     rust: ['rs'],
     shaderlab: ['shader'],
-    shellscript: ['shell', 'sh', 'zsh'],
+    shellscript: ['shell', 'sh'],
     stylus: ['styl'],
     typescript: ['ts'],
     vb: ['cmd'],


### PR DESCRIPTION
This fixes a few issues with the language selection:

- wolfram typo
- removes the filtering of bash and zsh filtering
- Sorts the list by label rather than key