### PR TITLE
Release 1.16.1

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -7,7 +7,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.16.0
+ * Version:           1.16.1
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82
 Tags:              block, code, syntax, snippet, highlighter, JavaScript, php, vs code
 Tested up to:      6.2
-Stable tag:        1.16.0
+Stable tag:        1.16.1
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -266,6 +266,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+= 1.16.1 - 2023-05-01 =
 - Tweak: Removes the filtering of bash and zsh filtering
 - Fix: Better language sorting (by label instead of key)
 - Fix: Fix typo in Wolfram language key


### PR DESCRIPTION
- Tweak: Removes the filtering of bash and zsh filtering
- Fix: Better language sorting (by label instead of key)
- Fix: Fix typo in Wolfram language key