### PR TITLE
Autofocus on Editor

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Code Block Pro - Beautiful Syntax Highlighting ===
-Contributors:      kbat82
+Contributors:      kbat82, dcooney
 Tags:              block, code, syntax, snippet, highlighter, JavaScript, php, vs code
 Tested up to:      6.2
 Stable tag:        1.18.0

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -224,6 +224,7 @@ export const Edit = ({
             <Editor
                 value={decode(code)}
                 onValueChange={handleChange}
+                autoFocus={!code ? true : false}
                 padding={{
                     top: disablePadding ? 0 : 16,
                     bottom: disablePadding || hasFooter ? 0 : 16,

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -224,7 +224,7 @@ export const Edit = ({
             <Editor
                 value={decode(code)}
                 onValueChange={handleChange}
-                autoFocus={!code ? true : false}
+                autoFocus={!code}
                 padding={{
                     top: disablePadding ? 0 : 16,
                     bottom: disablePadding || hasFooter ? 0 : 16,


### PR DESCRIPTION
This PR simply adds autofocus to the `<Editor/>` when the Code Pro block has been added to the block editor.
If the code block has `code` autofocus is set to `false` as it assumes the block hasn't been just added to the block editor.


The use-case for this is that I frequently:

1. Copy code from another source.
2. Open WordPress, and add Code Pro block.
3. `Cmd + V` but nothing happens because the focus is not on the editor :)

This PR solves the above by auto-focusing after the block has been added.

![image](https://github.com/KevinBatdorf/code-block-pro/assets/428624/99985d3c-7595-4bd5-a95b-c4711152b3fd)
