### PR TITLE
Release 1.19.0

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -7,7 +7,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.18.0
+ * Version:           1.19.0
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/readme.txt
+++ b/readme.txt
@@ -300,6 +300,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 - Feature: Add Fantasque Sans Mono (https://github.com/belluzj/fantasque-sans)
 - Feature: Add Comic Mono font (https://github.com/dtinth/comic-mono-font)
 - Tweak: Default to Jetbrains Mono font
+- Tweak: Rename the "Styling" panel to "Font Styling"
 - Tweak: Remove line highlights on hover when blurred
 - Tweak: Add minor adjustments for fonts to normalize line heights
 - Fix: Block will be auto-focused on insert - WP6.2 regression

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82, dcooney
 Tags:              block, code, syntax, snippet, highlighter, JavaScript, php, vs code
 Tested up to:      6.2
-Stable tag:        1.18.0
+Stable tag:        1.19.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -296,6 +296,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+= 1.19.0 - 2023-06-18 =
 - Feature: Add Fantasque Sans Mono (https://github.com/belluzj/fantasque-sans)
 - Feature: Add Comic Mono font (https://github.com/dtinth/comic-mono-font)
 - Tweak: Default to Jetbrains Mono font

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -262,7 +262,7 @@ export const SidebarControls = ({
                 setAttributes={setAttributes}
             />
             <PanelBody
-                title={__('Styling', 'code-block-pro')}
+                title={__('Font Styling', 'code-block-pro')}
                 initialOpen={false}>
                 <div
                     className="code-block-pro-editor"


### PR DESCRIPTION
- Feature: Add Fantasque Sans Mono (https://github.com/belluzj/fantasque-sans)
- Feature: Add Comic Mono font (https://github.com/dtinth/comic-mono-font)
- Tweak: Default to Jetbrains Mono font
- Tweak: Remove line highlights on hover when blurred
- Tweak: Add minor adjustments for fonts to normalize line heights
- Fix: Block will be auto-focused on insert - WP6.2 regression
- Fix: Line highlight hover width was not rendering correctly
- Fix: Line highlighter will find the longest line to use as the highlighter width