### PR TITLE
Fix empty span line number bug

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -296,6 +296,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Fix: Fixes an issue in the editor where some languages output an empty span tag that breaks the line number flow.
+
 = 1.19.0 - 2023-06-18 =
 - Feature: Add Fantasque Sans Mono (https://github.com/belluzj/fantasque-sans)
 - Feature: Add Comic Mono font (https://github.com/dtinth/comic-mono-font)

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -44,11 +44,13 @@
 .code-block-pro-editor pre .line {
     @apply relative inline-block w-full;
 }
-.code-block-pro-editor:not(.padding-disabled) pre .line:empty {
-    @apply block;
-}
-.code-block-pro-editor.padding-disabled.cbp-has-line-numbers pre .line:empty {
-    @apply block;
+.code-block-pro-editor pre {
+    .line:empty {
+        @apply block;
+    }
+    .line span:empty {
+        @apply inline-block;
+    }
 }
 .code-block-pro-editor.cbp-has-line-numbers
     pre


### PR DESCRIPTION
This fixes a bug where an empty span rendered (only on some languages, and not sure why it renders anything) will disrupt the line numbers

![Screen Shot 2023-06-21 at 9 31 27 AM](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/85a2bae2-b435-4620-b757-f85e6959b20a)

After

![Screen Shot 2023-06-21 at 9 31 34 AM](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/b17e47ac-b7e0-4b8a-b7f2-9c0a435152ac)
