### PR TITLE
Add tab size setting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -303,6 +303,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Feature: Added a tab size setting for when using the editor to add code. Defaults to 2 spaces.
+
 = 1.20.0 - 2023-06-25 =
 - Feature: Added the following languages: Ledger (Beancount), Cypher (cql), Glimmer js/ts, JSONL, Narrat (nar), Nextflow (nf), Vyper (vy)
 - Fix: Fixes an issue in the editor where some languages output an empty span tag that breaks the line number flow.

--- a/src/block.json
+++ b/src/block.json
@@ -44,7 +44,8 @@
         "frame": { "type": "boolean" },
         "renderType": { "type": "string", "default": "code" },
         "label": { "type": "string", "default": "" },
-        "copyButton": { "type": "boolean" }
+        "copyButton": { "type": "boolean" },
+        "tabSize": { "type": "number" }
     },
     "supports": {
         "html": false,

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -12,7 +12,6 @@ import Editor from 'react-simple-code-editor';
 import { useDefaults } from '../hooks/useDefaults';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguageStore } from '../state/language';
-import { useSettingsStore } from '../state/settings';
 import { AttributesPropsAndSetter, Lang } from '../types';
 import { parseJSONArrayWithRanges } from '../util/arrayHelpers';
 import { computeLineHighlightColor } from '../util/colors';
@@ -47,9 +46,8 @@ export const Edit = ({
         enableMaxHeight,
         editorHeight,
         useDecodeURI,
+        tabSize,
     } = attributes;
-
-    const { editorTabSize } = useSettingsStore();
 
     const textAreaRef = useRef<HTMLDivElement>(null);
     const handleChange = (code: string) =>
@@ -229,7 +227,7 @@ export const Edit = ({
                 onValueChange={handleChange}
                 // eslint-disable-next-line jsx-a11y/no-autofocus -- Only autofocus in the unintended case that there is no code (e.g. on initial insert)
                 autoFocus={!code}
-                tabSize={editorTabSize || 2}
+                tabSize={tabSize || 2}
                 padding={{
                     top: disablePadding ? 0 : 16,
                     bottom: disablePadding || hasFooter ? 0 : 16,

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -12,6 +12,7 @@ import Editor from 'react-simple-code-editor';
 import { useDefaults } from '../hooks/useDefaults';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguageStore } from '../state/language';
+import { useSettingsStore } from '../state/settings';
 import { AttributesPropsAndSetter, Lang } from '../types';
 import { parseJSONArrayWithRanges } from '../util/arrayHelpers';
 import { computeLineHighlightColor } from '../util/colors';
@@ -47,6 +48,8 @@ export const Edit = ({
         editorHeight,
         useDecodeURI,
     } = attributes;
+
+    const { editorTabSize } = useSettingsStore();
 
     const textAreaRef = useRef<HTMLDivElement>(null);
     const handleChange = (code: string) =>
@@ -226,6 +229,7 @@ export const Edit = ({
                 onValueChange={handleChange}
                 // eslint-disable-next-line jsx-a11y/no-autofocus -- Only autofocus in the unintended case that there is no code (e.g. on initial insert)
                 autoFocus={!code}
+                tabSize={editorTabSize || 2}
                 padding={{
                     top: disablePadding ? 0 : 16,
                     bottom: disablePadding || hasFooter ? 0 : 16,

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -16,7 +16,6 @@ import { __ } from '@wordpress/i18n';
 import { useLanguage } from '../../hooks/useLanguage';
 import { useGlobalStore } from '../../state/global';
 import { useLanguageStore } from '../../state/language';
-import { useSettingsStore } from '../../state/settings';
 import { useThemeStore } from '../../state/theme';
 import { AttributesPropsAndSetter, Lang } from '../../types';
 import { languages } from '../../util/languages';
@@ -43,7 +42,6 @@ export const SidebarControls = ({
     const { recentLanguages } = useLanguageStore();
     const { updateThemeHistory } = useThemeStore();
     const { bringAttentionToPanel } = useGlobalStore();
-    const { editorTabSize, setEditorTabSize } = useSettingsStore();
     const { headerType, footerType } = attributes;
     const languagesSorted = new Map(
         Object.entries(languages).sort((a, b) => a[1].localeCompare(b[1])),
@@ -377,16 +375,17 @@ export const SidebarControls = ({
                         autoComplete="off"
                         type="number"
                         data-cy="editor-tab-size"
-                        label={__(
-                            'Editor tab size (universal)',
-                            'code-block-pro',
-                        )}
+                        label={__('Editor tab size', 'code-block-pro')}
                         help={__(
-                            'The number of characters to insert when pressing tab key. This setting will apply everywhere.',
+                            'The number of characters to insert when pressing tab key.',
                             'code-block-pro',
                         )}
-                        value={editorTabSize}
-                        onChange={setEditorTabSize}
+                        value={attributes.tabSize}
+                        onChange={(size) => {
+                            const tabSize = size ? Number(size) : undefined;
+                            setAttributes({ tabSize });
+                            updateThemeHistory({ ...attributes, tabSize });
+                        }}
                     />
                 </BaseControl>
             </PanelBody>

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 import { useLanguage } from '../../hooks/useLanguage';
 import { useGlobalStore } from '../../state/global';
 import { useLanguageStore } from '../../state/language';
+import { useSettingsStore } from '../../state/settings';
 import { useThemeStore } from '../../state/theme';
 import { AttributesPropsAndSetter, Lang } from '../../types';
 import { languages } from '../../util/languages';
@@ -42,6 +43,7 @@ export const SidebarControls = ({
     const { recentLanguages } = useLanguageStore();
     const { updateThemeHistory } = useThemeStore();
     const { bringAttentionToPanel } = useGlobalStore();
+    const { editorTabSize, setEditorTabSize } = useSettingsStore();
     const { headerType, footerType } = attributes;
     const languagesSorted = new Map(
         Object.entries(languages).sort((a, b) => a[1].localeCompare(b[1])),
@@ -367,6 +369,24 @@ export const SidebarControls = ({
                                 useDecodeURI,
                             });
                         }}
+                    />
+                </BaseControl>
+                <BaseControl id="code-block-pro-editor-tab-size">
+                    <TextControl
+                        spellCheck={false}
+                        autoComplete="off"
+                        type="number"
+                        data-cy="editor-tab-size"
+                        label={__(
+                            'Editor tab size (universal)',
+                            'code-block-pro',
+                        )}
+                        help={__(
+                            'The number of characters to insert when pressing tab key. This setting will apply everywhere.',
+                            'code-block-pro',
+                        )}
+                        value={editorTabSize}
+                        onChange={setEditorTabSize}
                     />
                 </BaseControl>
             </PanelBody>

--- a/src/hooks/useDefaults.ts
+++ b/src/hooks/useDefaults.ts
@@ -20,6 +20,7 @@ export const useDefaults = ({
         disablePadding,
         lineNumbers,
         highlightingHover,
+        tabSize,
     } = attributes;
     const {
         previousTheme,
@@ -34,6 +35,7 @@ export const useDefaults = ({
         previousHighlightingHover,
         previousCopyButton,
         previousButtonTheme,
+        previousTabSize,
     } = useThemeStore();
     const ready = useThemeStoreReady();
     const once = useRef(false);
@@ -111,6 +113,12 @@ export const useDefaults = ({
             return;
         setAttributes({ lineNumbers: previousLineNumbers });
     }, [previousLineNumbers, lineNumbers, setAttributes]);
+
+    useEffect(() => {
+        if (once.current) return;
+        if (tabSize !== undefined || previousTabSize === undefined) return;
+        setAttributes({ tabSize: previousTabSize });
+    }, [previousTabSize, tabSize, setAttributes]);
 
     useEffect(() => {
         if (once.current) return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,6 +66,7 @@ registerBlockType<Attributes>(blockConfig.name, {
         copyButton: { type: 'boolean' },
         buttonTheme: { type: 'string' },
         useDecodeURI: { type: 'boolean', default: false },
+        tabSize: { type: 'number', default: 2 },
     },
     // Need to add these here to avoid TS type errors
     supports: {

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -6,10 +6,8 @@ import { createJSONStorage, devtools, persist } from 'zustand/middleware';
 type Settings = {
     seenNotices: string[];
     hiddenThemes: string[];
-    editorTabSize: number | '';
     setSeenNotice: (notice: string) => void;
     toggleHiddenTheme: (theme: string) => void;
-    setEditorTabSize: (editorTabSize: number | string) => void;
 };
 const path = '/code-block-pro/v1/settings';
 const getSettings = async (name: string) => {
@@ -21,7 +19,6 @@ const getSettings = async (name: string) => {
 const defaultSettings = {
     seenNotices: [],
     hiddenThemes: [],
-    editorTabSize: 2,
 };
 const storage = {
     getItem: async (name: string) => {
@@ -66,13 +63,6 @@ export const useSettingsStore = create<Settings>()(
                             ? state.hiddenThemes.filter((t) => t !== theme)
                             : [...state.hiddenThemes, theme],
                     }));
-                },
-                setEditorTabSize(editorTabSize) {
-                    set({
-                        editorTabSize: editorTabSize
-                            ? Number(editorTabSize)
-                            : '',
-                    });
                 },
             }),
             { name: 'Code Block Pro Settings' },

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -6,8 +6,10 @@ import { createJSONStorage, devtools, persist } from 'zustand/middleware';
 type Settings = {
     seenNotices: string[];
     hiddenThemes: string[];
+    editorTabSize: number | '';
     setSeenNotice: (notice: string) => void;
     toggleHiddenTheme: (theme: string) => void;
+    setEditorTabSize: (editorTabSize: number | string) => void;
 };
 const path = '/code-block-pro/v1/settings';
 const getSettings = async (name: string) => {
@@ -19,6 +21,7 @@ const getSettings = async (name: string) => {
 const defaultSettings = {
     seenNotices: [],
     hiddenThemes: [],
+    editorTabSize: 2,
 };
 const storage = {
     getItem: async (name: string) => {
@@ -63,6 +66,13 @@ export const useSettingsStore = create<Settings>()(
                             ? state.hiddenThemes.filter((t) => t !== theme)
                             : [...state.hiddenThemes, theme],
                     }));
+                },
+                setEditorTabSize(editorTabSize) {
+                    set({
+                        editorTabSize: editorTabSize
+                            ? Number(editorTabSize)
+                            : '',
+                    });
                 },
             }),
             { name: 'Code Block Pro Settings' },

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -17,6 +17,7 @@ type ThemeType = {
     previousHighlightingHover?: boolean;
     previousCopyButton: boolean;
     previousButtonTheme: string;
+    previousTabSize: number;
     updateThemeHistory: (settings: Partial<Attributes>) => void;
 };
 const path = '/code-block-pro/v1/settings';
@@ -39,6 +40,7 @@ const defaultSettings = {
     previousHighlightingHover: undefined,
     previousCopyButton: true,
     previousButtonTheme: 'heroicons',
+    previousTabSize: 2,
 };
 const storage = {
     getItem: async (name: string) => {
@@ -85,6 +87,7 @@ export const useThemeStore = create<ThemeType>()(
                         previousHighlightingHover: attributes.highlightingHover,
                         previousCopyButton: attributes.copyButton,
                         previousButtonTheme: attributes.buttonTheme,
+                        previousTabSize: attributes.tabSize,
                     }));
                 },
             }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export type Attributes = {
     copyButton: boolean;
     buttonTheme: string;
     useDecodeURI: boolean;
+    tabSize: number;
 };
 export interface AttributesPropsAndSetter {
     attributes: Attributes;


### PR DESCRIPTION
This allows you to set a tab size to use when editing. It's set per block so eventually there can be "language profiles" that respect common tab widths when editing.

![Screen Shot 2023-07-08 at 12 22 42 PM](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/1d7ff0e1-c515-45f3-961d-a0e2b67294b7)
