### PR TITLE
Add better support for tabs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -304,6 +304,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 == Changelog ==
 
 - Feature: Added the Non-Ligature version of Jetbrains Mono
+- Fix: Fixed a spacing issue with tabs + line numbers
+- Fix: Fixed a bug where the line highlighter would calc the longest highlighted line rather than longest line
+- Tweak: Added pointer-events none to line blurs that are not removed on hover
 
 = 1.21.0 - 2023-07-09 =
 - Feature: Added a second copy button to choose from

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -58,9 +58,17 @@ const handleHighlighter = () => {
         // If the code block expands, we need to recalculate the width
         new ResizeObserver(() => {
             // find the longest line
+            const lines = codeBlock.querySelectorAll('span.line');
             codeBlock.style.setProperty('--cbp-block-width', 'unset');
-            const longestLine = Array.from(highlighters).reduce((a, b) =>
+            const longestLine = Array.from(lines).reduce((a, b) =>
                 a.offsetWidth > b.offsetWidth ? a : b,
+            );
+            const highestLineHeight = Array.from(lines).reduce((a, b) =>
+                a.offsetHeight > b.offsetHeight ? a : b,
+            );
+            codeBlock.style.setProperty(
+                '--cbp-block-height',
+                highestLineHeight.offsetHeight + 'px',
             );
             codeBlock.style.setProperty(
                 '--cbp-block-width',

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -9,7 +9,8 @@
     }
 }
 .wp-block-kevinbatdorf-code-block-pro {
-    pre, pre * {
+    pre,
+    pre * {
         font-size: inherit;
         line-height: inherit;
     }
@@ -42,8 +43,16 @@
     pre
     code
     .line {
-    @apply inline-block;
-    min-width: calc(var(--cbp-block-width, 100%));
+    @apply inline-block align-top;
+    min-width: var(--cbp-block-width, 100%);
+}
+.wp-block-kevinbatdorf-code-block-pro.cbp-has-line-numbers:not(
+        .code-block-pro-editor
+    )
+    pre
+    code
+    .line {
+    padding-left: calc(12px + var(--cbp-line-number-width, auto));
 }
 .wp-block-kevinbatdorf-code-block-pro.cbp-has-line-numbers:not(
         .code-block-pro-editor
@@ -70,21 +79,25 @@
     pre
     code
     .line:not(.cbp-line-number-disabled)::before {
-    @apply inline-block text-right opacity-50 transition-opacity duration-500;
-    margin-right: 12px;
+    @apply absolute left-0 text-right opacity-50 transition-opacity duration-500;
     content: counter(step);
     color: var(--cbp-line-number-color, #999);
     width: var(--cbp-line-number-width, auto);
     user-select: none;
     counter-increment: step;
 }
+.wp-block-kevinbatdorf-code-block-pro.cbp-highlight-hover .line {
+    min-height: var(--cbp-block-height, 100%);
+}
 .wp-block-kevinbatdorf-code-block-pro {
-    &.cbp-highlight-hover:not(.cbp-blur-enabled:not(.cbp-unblur-on-hover)) .line:hover,
+    &.cbp-highlight-hover:not(.cbp-blur-enabled:not(.cbp-unblur-on-hover))
+        .line:hover,
     .line.cbp-no-blur:hover,
     .line.cbp-line-highlight {
         .cbp-line-highlighter {
-            @apply w-full pointer-events-none absolute top-0 h-full;
+            @apply w-full pointer-events-none absolute top-0;
             background: var(--cbp-line-highlight-color, rgb(14 165 233/0.2));
+            min-height: var(--cbp-block-height, 100%);
             min-width: calc(var(--cbp-block-width, 100%) + 16px);
             left: -16px;
             [data-code-block-pro-font-family='Code-Pro-Comic-Mono.ttf']& {
@@ -127,12 +140,12 @@
     pre
     .line:not(.cbp-no-blur) {
     filter: blur(1px);
-    @apply opacity-40 transition-all duration-200;
+    @apply opacity-40 transition-all duration-200 pointer-events-none;
 }
 .wp-block-kevinbatdorf-code-block-pro.cbp-blur-enabled.cbp-unblur-on-hover:hover
     pre
     .line:not(.cbp-no-blur) {
-    @apply blur-none opacity-100;
+    @apply blur-none opacity-100 pointer-events-auto;
 }
 .wp-block-kevinbatdorf-code-block-pro:not(.code-block-pro-editor) pre * {
     font-family: inherit;


### PR DESCRIPTION
Currently if using tabs with line numbers, the first tab is truncated by the line number. This fixes that. Will follow up with a PR to add tab specific features like width, etc

![Screen Shot 2023-07-22 at 11 24 28 AM](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/baaa13bd-4c0c-4636-a111-21a56d3bfe16)


I also added some other line styling fixes, including highlighter length and blur pointer events. See the changelog for details