### PR TITLE
Add support to transform to core code block

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -303,6 +303,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Feature: Added a way to convert back into a core code block
 - Feature: Added the Non-Ligature version of Jetbrains Mono
 - Fix: Fixed a spacing issue with tabs + line numbers
 - Fix: Fixed a bug where the line highlighter would calc the longest highlighted line rather than longest line

--- a/src/editor/transforms.ts
+++ b/src/editor/transforms.ts
@@ -1,0 +1,23 @@
+import { createBlock } from '@wordpress/blocks';
+import blockConfig from '../block.json';
+import { Attributes, Lang } from '../types';
+import { getMainAlias } from '../util/languages';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const transformToCBP = (attrs: any) => {
+    const { content, language } = attrs;
+    const decode = (value: string) => {
+        const txt = document.createElement('textarea');
+        txt.innerHTML = value;
+        return txt.value;
+    };
+    return createBlock(blockConfig.name, {
+        code: content ? decode(content) : undefined,
+        language: getMainAlias(language) as Lang,
+    });
+};
+
+export const transformFromCBP = (attrs: Attributes) => {
+    const { code: content } = attrs;
+    return createBlock('core/code', { content });
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import { useBlockProps as blockProps } from '@wordpress/block-editor';
-import { createBlock, registerBlockType } from '@wordpress/blocks';
+import { registerBlockType } from '@wordpress/blocks';
 import { addFilter, applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
@@ -14,12 +14,12 @@ import { ButtonList } from './editor/components/buttons/ButtonList';
 import { SidebarControls } from './editor/controls/Sidebar';
 import { ToolbarControls } from './editor/controls/Toolbar';
 import './editor/editor.css';
+import { transformToCBP, transformFromCBP } from './editor/transforms';
 import { BlockOutput } from './front/BlockOutput';
 import { blockIcon } from './icons';
-import { Attributes, Lang, ThemeOption } from './types';
+import { Attributes, ThemeOption } from './types';
 import { findLineNumberColor } from './util/colors';
 import { fontFamilyLong, maybeClamp } from './util/fonts';
-import { getMainAlias } from './util/languages';
 
 registerBlockType<Attributes>(blockConfig.name, {
     ...blockConfig,
@@ -170,20 +170,14 @@ registerBlockType<Attributes>(blockConfig.name, {
             {
                 type: 'block',
                 blocks: ['core/code', 'syntaxhighlighter/code'],
-                transform: (attrs) => {
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore-next-line - Why is this reading the block generic?
-                    const { content, language } = attrs;
-                    const decode = (value: string) => {
-                        const txt = document.createElement('textarea');
-                        txt.innerHTML = value;
-                        return txt.value;
-                    };
-                    return createBlock(blockConfig.name, {
-                        code: content ? decode(content) : undefined,
-                        language: getMainAlias(language) as Lang,
-                    });
-                },
+                transform: transformToCBP,
+            },
+        ],
+        to: [
+            {
+                type: 'block',
+                blocks: ['core/code'],
+                transform: transformFromCBP,
             },
         ],
     },


### PR DESCRIPTION
This adds support for converting a code block pro block back into a standard core code block.

![Screen Shot 2023-07-22 at 3 31 12 PM](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/c24ccac4-a85e-4efe-862e-bcd7e8ba69db)

closes #211 