### PR TITLE
Add editor support for tabs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -303,6 +303,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Feature: Added tab support in the editor, with spacing options
 - Feature: Added a way to convert back into a core code block
 - Feature: Added the Non-Ligature version of Jetbrains Mono
 - Fix: Fixed a spacing issue with tabs + line numbers

--- a/src/block.json
+++ b/src/block.json
@@ -45,7 +45,8 @@
         "renderType": { "type": "string", "default": "code" },
         "label": { "type": "string", "default": "" },
         "copyButton": { "type": "boolean" },
-        "tabSize": { "type": "number" }
+        "tabSize": { "type": "number" },
+        "useTabs": { "type": "boolean" }
     },
     "supports": {
         "html": false,

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -47,6 +47,7 @@ export const Edit = ({
         editorHeight,
         useDecodeURI,
         tabSize,
+        useTabs,
     } = attributes;
 
     const textAreaRef = useRef<HTMLDivElement>(null);
@@ -227,7 +228,8 @@ export const Edit = ({
                 onValueChange={handleChange}
                 // eslint-disable-next-line jsx-a11y/no-autofocus -- Only autofocus in the unintended case that there is no code (e.g. on initial insert)
                 autoFocus={!code}
-                tabSize={tabSize || 2}
+                tabSize={useTabs ? 1 : tabSize || 2}
+                insertSpaces={!useTabs}
                 padding={{
                     top: disablePadding ? 0 : 16,
                     bottom: disablePadding || hasFooter ? 0 : 16,

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -377,7 +377,7 @@ export const SidebarControls = ({
                         data-cy="editor-tab-size"
                         label={__('Editor tab size', 'code-block-pro')}
                         help={__(
-                            'The number of characters to insert when pressing tab key.',
+                            'The number of spaces to insert when pressing tab key.',
                             'code-block-pro',
                         )}
                         value={attributes.tabSize}
@@ -385,6 +385,22 @@ export const SidebarControls = ({
                             const tabSize = size ? Number(size) : undefined;
                             setAttributes({ tabSize });
                             updateThemeHistory({ ...attributes, tabSize });
+                        }}
+                    />
+                    <CheckboxControl
+                        data-cy="use-tabs"
+                        label={__('Use Real Tabs', 'code-block-pro')}
+                        help={__(
+                            'Inserts an actual tab character instead of a space. The width defined above.',
+                            'code-block-pro',
+                        )}
+                        checked={attributes.useTabs}
+                        onChange={(useTabs) => {
+                            setAttributes({ useTabs });
+                            updateThemeHistory({
+                                ...attributes,
+                                useTabs,
+                            });
                         }}
                     />
                 </BaseControl>

--- a/src/front/BlockOutput.tsx
+++ b/src/front/BlockOutput.tsx
@@ -18,7 +18,6 @@ export const BlockOutput = ({ attributes }: { attributes: Attributes }) => {
         defaultThemes,
     ) as ThemeOption;
     const styles = themes[attributes.theme]?.styles;
-
     return (
         <div
             {...blockProps.save({
@@ -61,6 +60,14 @@ export const BlockOutput = ({ attributes }: { attributes: Attributes }) => {
                         attributes.lineHeight,
                         attributes.clampFonts,
                     ),
+                    '--cbp-tab-width':
+                        attributes.useTabs === undefined
+                            ? undefined // bw compatibility
+                            : String(attributes.tabSize),
+                    tabSize:
+                        attributes.useTabs === undefined
+                            ? undefined // bw compatibility
+                            : 'var(--cbp-tab-width, 2)',
                     ...Object.entries(styles ?? {}).reduce(
                         (acc, [key, value]) => ({
                             ...acc,

--- a/src/hooks/useDefaults.ts
+++ b/src/hooks/useDefaults.ts
@@ -21,6 +21,7 @@ export const useDefaults = ({
         lineNumbers,
         highlightingHover,
         tabSize,
+        useTabs,
     } = attributes;
     const {
         previousTheme,
@@ -36,6 +37,7 @@ export const useDefaults = ({
         previousCopyButton,
         previousCopyButtonType,
         previousTabSize,
+        previousUseTabs,
     } = useThemeStore();
     const ready = useThemeStoreReady();
     const once = useRef(false);
@@ -119,6 +121,12 @@ export const useDefaults = ({
         if (tabSize !== undefined || previousTabSize === undefined) return;
         setAttributes({ tabSize: previousTabSize });
     }, [previousTabSize, tabSize, setAttributes]);
+
+    useEffect(() => {
+        if (once.current) return;
+        if (useTabs !== undefined || previousUseTabs === undefined) return;
+        setAttributes({ useTabs: previousUseTabs });
+    }, [previousUseTabs, useTabs, setAttributes]);
 
     useEffect(() => {
         if (once.current) return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,6 +67,7 @@ registerBlockType<Attributes>(blockConfig.name, {
         copyButtonType: { type: 'string' },
         useDecodeURI: { type: 'boolean', default: false },
         tabSize: { type: 'number', default: 2 },
+        useTabs: { type: 'boolean' },
     },
     // Need to add these here to avoid TS type errors
     supports: {
@@ -130,6 +131,10 @@ registerBlockType<Attributes>(blockConfig.name, {
                                     ? attributes.lineHighlightColor
                                     : undefined,
                             '--cbp-line-height': attributes.lineHeight,
+                            tabSize:
+                                attributes.useTabs === undefined
+                                    ? undefined // bw compatability
+                                    : attributes.tabSize,
                             // Disabled as ligatures will break the editor line widths
                             // fontFamily: fontFamilyLong(attributes.fontFamily),
                             fontFamily: fontFamilyLong(''),

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -18,6 +18,7 @@ type ThemeType = {
     previousCopyButton: boolean;
     previousCopyButtonType: string;
     previousTabSize: number;
+    previousUseTabs?: boolean;
     updateThemeHistory: (settings: Partial<Attributes>) => void;
 };
 const path = '/code-block-pro/v1/settings';
@@ -41,6 +42,7 @@ const defaultSettings = {
     previousCopyButton: true,
     previousCopyButtonType: 'heroicons',
     previousTabSize: 2,
+    previousUseTabs: undefined,
 };
 const storage = {
     getItem: async (name: string) => {
@@ -88,6 +90,7 @@ export const useThemeStore = create<ThemeType>()(
                         previousCopyButton: attributes.copyButton,
                         previousCopyButtonType: attributes.copyButtonType,
                         previousTabSize: attributes.tabSize,
+                        previousUseTabs: attributes.useTabs,
                     }));
                 },
             }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export type Attributes = {
     copyButtonType: string;
     useDecodeURI: boolean;
     tabSize: number;
+    useTabs: boolean;
 };
 export interface AttributesPropsAndSetter {
     attributes: Attributes;


### PR DESCRIPTION
This adds editor support for inserting tabs. The tab width set in the tab size setting will define the tab width in the editor and the front end

![Screen Shot 2023-07-22 at 5 39 16 PM](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/c774c048-1721-496f-afed-123d07aecf2f)
