### PR TITLE
Release 1.22.0

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -7,7 +7,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.21.0
+ * Version:           1.22.0
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82, dcooney
 Tags:              block, code, syntax, snippet, highlighter, JavaScript, php, vs code
 Tested up to:      6.3
-Stable tag:        1.21.0
+Stable tag:        1.22.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -303,6 +303,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+= 1.22.0 - 2023-07-22 =
 - Feature: Added tab support in the editor, with spacing options
 - Feature: Added a way to convert back into a core code block
 - Feature: Added the Non-Ligature version of Jetbrains Mono


### PR DESCRIPTION
- Feature: Added tab support in the editor, with spacing options
- Feature: Added a way to convert back into a core code block
- Feature: Added the Non-Ligature version of Jetbrains Mono
- Fix: Fixed a spacing issue with tabs + line numbers
- Fix: Fixed a bug where the line highlighter would calc the longest highlighted line rather than longest line
- Tweak: Added pointer-events none to line blurs that are not removed on hover