### PR TITLE
Add tabsize to theme preview

### DIFF
--- a/src/editor/components/ThemeSelect.tsx
+++ b/src/editor/components/ThemeSelect.tsx
@@ -17,6 +17,7 @@ type ThemeSelectProps = {
     fontFamily: string;
     search: string;
     clampFonts: boolean;
+    tabSize: number;
     onClick: (slug: Theme) => void;
 };
 export const ThemeSelect = (props: ThemeSelectProps) => {
@@ -37,7 +38,9 @@ export const ThemeSelect = (props: ThemeSelectProps) => {
     const priorityThemes = getPriorityThemes();
 
     return (
-        <div className="code-block-pro-editor">
+        <div
+            className="code-block-pro-editor"
+            style={{ tabSize: props.tabSize }}>
             {props.search?.length > 0 ? (
                 <BaseControl id="add-on-themes">
                     {priorityThemes?.length > 0 ? null : (


### PR DESCRIPTION
This adds the tabsize value to the sidebar theme previews, so they match the editor

![Screen Shot 2023-07-23 at 12 34 27 PM](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/e436e68e-e195-4644-8b52-6c0579c3bd21)
