### PR TITLE
Improve decoding on some sequences

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -305,6 +305,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Fix: There was an issue with the decoding with some sequences that would cause a block invalidation error.
+
 = 1.22.0 - 2023-07-22 =
 - Feature: Added tab support in the editor, with spacing options
 - Feature: Added a way to convert back into a core code block

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -62,13 +62,11 @@ export const Edit = ({
     useDefaults({ attributes, setAttributes });
 
     const decode = useCallback(
-        (code: string) =>
-            useDecodeURI ? decodeURIComponent(code) : decodeEntities(code),
+        (code: string) => (useDecodeURI ? code : decodeEntities(code)),
         [useDecodeURI],
     );
     const encode = useCallback(
-        (code: string) =>
-            useDecodeURI ? encodeURIComponent(code) : escapeHTML(code),
+        (code: string) => (useDecodeURI ? code : escapeHTML(code)),
         [useDecodeURI],
     );
 

--- a/src/editor/components/buttons/copy/CopyButton.tsx
+++ b/src/editor/components/buttons/copy/CopyButton.tsx
@@ -29,8 +29,7 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
             data-encoded={attributes.useDecodeURI ? true : undefined}
             data-code={stripAnsi(
                 attributes.useDecodeURI
-                    ? // Encode again otherwise WP will decode it
-                      encodeURIComponent(attributes.code ?? '')
+                    ? encodeURIComponent(attributes.code ?? '')
                     : attributes.code ?? '',
             )}
             style={{

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -356,7 +356,7 @@ export const SidebarControls = ({
                         data-cy="use-decode-uri"
                         label={__('Allow HTML Entites', 'code-block-pro')}
                         help={__(
-                            'Select this to allow HTML entities such as &lt; and &gt; to be displayed.',
+                            'Select this to allow HTML entities such as &lt; and &gt; to be displayed. You may need to re-add the code after changing this',
                             'code-block-pro',
                         )}
                         checked={attributes.useDecodeURI}

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -19,7 +19,7 @@ const handleCopyButton = () => {
             event.preventDefault();
             const b = target?.closest('span');
             const code = b?.dataset?.encoded
-                ? decodeURIComponent(decodeURIComponent(b?.dataset?.code))
+                ? decodeURIComponent(b?.dataset?.code)
                 : b?.dataset?.code;
             copy(code ?? '', {
                 format: 'text/plain',


### PR DESCRIPTION
This improves encoding/decoding on some sequences, like `G%|X~!"` that would break the decoder. 

In summary, the change will not _not_ encode if saving into the database except for the data attribute. 

closes #222 