### PR TITLE
Fix core code block conversion

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -305,6 +305,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Fix: Added escapeHTML wrapper on code -> code pro transform function
+
 = 1.22.0 - 2023-07-22 =
 - Feature: Added tab support in the editor, with spacing options
 - Feature: Added a way to convert back into a core code block

--- a/src/editor/transforms.ts
+++ b/src/editor/transforms.ts
@@ -1,4 +1,5 @@
 import { createBlock } from '@wordpress/blocks';
+import { escapeHTML } from '@wordpress/escape-html';
 import blockConfig from '../block.json';
 import { Attributes, Lang } from '../types';
 import { getMainAlias } from '../util/languages';
@@ -12,7 +13,7 @@ export const transformToCBP = (attrs: any) => {
         return txt.value;
     };
     return createBlock(blockConfig.name, {
-        code: content ? decode(content) : undefined,
+        code: content ? escapeHTML(decode(content)) : undefined,
         language: getMainAlias(language) as Lang,
     });
 };


### PR DESCRIPTION
This fixes a bug where converting the core code block would not properly escape some html items

closes https://github.com/KevinBatdorf/code-block-pro/issues/225