### PR TITLE
Release 1.22.1

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -7,7 +7,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.22.0
+ * Version:           1.22.1
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82, dcooney
 Tags:              block, code, syntax, snippet, highlighter, JavaScript, php, js, vs code
 Tested up to:      6.3
-Stable tag:        1.22.0
+Stable tag:        1.22.1
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -305,6 +305,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+= 1.22.1 - 2023-07-30 =
 - Fix: Theme previews now respect the tabSize setting
 - Fix: Added escapeHTML wrapper on code to code pro transform function
 - Fix: Added some clarify on encoding, and added better edge cases handling

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -65,9 +65,9 @@ export const Edit = ({
         (code: string) => {
             if (useDecodeURI) {
                 try {
+                    // Here for bw compatability
                     return decodeURIComponent(code);
                 } catch (e) {
-                    // Covers sequences that fail the above
                     return code;
                 }
             }
@@ -79,9 +79,9 @@ export const Edit = ({
         (code: string) => {
             if (useDecodeURI) {
                 try {
+                    // Here for bw compatability
                     return encodeURIComponent(code);
                 } catch (e) {
-                    // Covers sequences that fail the above
                     return code;
                 }
             }


### PR DESCRIPTION
- Fix: Theme previews now respect the tabSize setting
- Fix: Added escapeHTML wrapper on code to code pro transform function
- Fix: Added some clarify on encoding, and added better edge cases handling
- Fix: Fixed an issue with the decoding with some sequences that would cause a block invalidation error.