### PR TITLE
WIP: calculate line number width using static values

### DIFF
--- a/cypress/e2e/styling.cy.js
+++ b/cypress/e2e/styling.cy.js
@@ -73,7 +73,7 @@ context('Styling', () => {
 
         cy.getPostContent('.wp-block[class$="code-block-pro"]')
             .invoke('attr', 'style')
-            .should('contain', 'font-family:Code-Pro-JetBrains-Mono');
+            .should('contain', 'Code-Pro-JetBrains-Mono');
 
         cy.get('#code-block-pro-font-family').select('Fira Code');
         cy.get('#code-block-pro-font-family').should(

--- a/cypress/e2e/styling.cy.js
+++ b/cypress/e2e/styling.cy.js
@@ -73,7 +73,7 @@ context('Styling', () => {
 
         cy.getPostContent('.wp-block[class$="code-block-pro"]')
             .invoke('attr', 'style')
-            .should('not.contain', 'font-family');
+            .should('contain', 'font-family:Code-Pro-JetBrains-Mono');
 
         cy.get('#code-block-pro-font-family').select('Fira Code');
         cy.get('#code-block-pro-font-family').should(

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -37,6 +37,7 @@ export const Edit = ({
         footerType,
         fontSize,
         fontFamily,
+        lineHeight,
         lineBlurs,
         lineHighlights,
         enableBlurring,
@@ -179,15 +180,16 @@ export const Edit = ({
         const lineNumbersWidth = getTextWidth(String(lnv), font);
         setAttributes({ lineNumbersWidth });
     }, [
+        lineNumbers,
+        startingLineNumber,
         code,
         loading,
         error,
         textAreaRef,
-        lineNumbers,
-        startingLineNumber,
+        setAttributes,
         fontSize,
         fontFamily,
-        setAttributes,
+        lineHeight,
     ]);
 
     if (!loading && !highlighter) {

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -17,6 +17,7 @@ import { parseJSONArrayWithRanges } from '../util/arrayHelpers';
 import { computeLineHighlightColor } from '../util/colors';
 import { getEditorLanguage } from '../util/languages';
 import { MissingPermissionsTip } from './components/misc/MissingPermissions';
+import { getTextWidth } from '../util/fonts';
 
 export const Edit = ({
     attributes,
@@ -36,7 +37,6 @@ export const Edit = ({
         footerType,
         fontSize,
         fontFamily,
-        lineHeight,
         lineBlurs,
         lineHighlights,
         enableBlurring,
@@ -170,35 +170,24 @@ export const Edit = ({
             setAttributes({ lineNumbersWidth: undefined });
             return;
         }
-        // Get the last line (assumingly the widest)
-        const lastLine = Array.from(
-            textAreaRef?.current?.querySelectorAll('.line') ?? [],
-        )?.at(-1) as HTMLElement;
-        // Make sure there are no width constraints
-        lastLine?.classList?.add('cbp-line-number-width-forced');
-        const lastLineWidth = lastLine?.getBoundingClientRect()?.width ?? 0;
-        // Add .cbp-line-number-disabled to disable the line number
-        lastLine?.classList.add('cbp-line-number-disabled');
-        // Re calculate the width of the last line
-        const newWidth = lastLine?.getBoundingClientRect()?.width ?? 0;
-        // Remove the classes
-        lastLine?.classList.remove('cbp-line-number-disabled');
-        lastLine?.classList?.remove('cbp-line-number-width-forced');
-        // Calculate the difference
-        if (lastLineWidth - newWidth > 0) {
-            setAttributes({ lineNumbersWidth: lastLineWidth - newWidth - 12 });
-        }
+
+        // Calulate the line numbers width
+        const codeLines = textAreaRef?.current?.querySelectorAll('.line');
+        const lnv = Number(startingLineNumber ?? 0) + (codeLines?.length ?? 0);
+        if (!codeLines?.[0]) return;
+        const { font } = getComputedStyle(codeLines?.[0]);
+        const lineNumbersWidth = getTextWidth(String(lnv), font);
+        setAttributes({ lineNumbersWidth });
     }, [
-        lineNumbers,
-        startingLineNumber,
         code,
         loading,
         error,
         textAreaRef,
-        setAttributes,
+        lineNumbers,
+        startingLineNumber,
         fontSize,
         fontFamily,
-        lineHeight,
+        setAttributes,
     ]);
 
     if (!loading && !highlighter) {

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -71,19 +71,6 @@
 .code-block-pro-editor.padding-disabled.cbp-has-line-numbers pre {
     @apply py-0;
 }
-/* Will make sure the line numbers are full width before calculating */
-.code-block-pro-editor.cbp-has-line-numbers
-    pre
-    .line.cbp-line-number-width-forced,
-.code-block-pro-editor.cbp-has-line-numbers pre .line.cbp-line-number-disabled {
-    @apply inline;
-}
-.code-block-pro-editor.cbp-has-line-numbers
-    pre
-    .line.cbp-line-number-width-forced::before {
-    width: auto !important;
-    position: initial;
-}
 .code-block-pro-editor .cbp-footer-link {
     @apply pointer-events-none no-underline;
 }
@@ -128,4 +115,24 @@
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
         monospace; /* no !important */
     direction: ltr;
+}
+@font-face {
+    font-family: 'Code-Pro-Fira-Code';
+    src: url('../fonts/Code-Pro-Fira-Code.woff2') format('woff2');
+}
+@font-face {
+    font-family: 'Code-Pro-JetBrains-Mono';
+    src: url('../fonts/Code-Pro-JetBrains-Mono.woff2') format('woff2');
+}
+@font-face {
+    font-family: 'Code-Pro-JetBrains-Mono-NL';
+    src: url('../fonts/Code-Pro-JetBrains-Mono-NL.ttf') format('truetype');
+}
+@font-face {
+    font-family: 'Code-Pro-Comic-Mono';
+    src: url('../fonts/Code-Pro-Comic-Mono.ttf') format('truetype');
+}
+@font-face {
+    font-family: 'Code-Pro-Fantasque-Sans-Mono';
+    src: url('../fonts/Code-Pro-Fantasque-Sans-Mono.woff2') format('woff2');
 }

--- a/src/front/BlockOutput.tsx
+++ b/src/front/BlockOutput.tsx
@@ -12,60 +12,82 @@ import { fontFamilyLong, maybeClamp } from '../util/fonts';
 import './style.css';
 
 export const BlockOutput = ({ attributes }: { attributes: Attributes }) => {
+    const {
+        clampFonts,
+        code,
+        codeHTML,
+        disablePadding,
+        enableBlurring,
+        enableHighlighting,
+        footerType,
+        fontSize,
+        fontFamily,
+        highestLineNumber,
+        highlightingHover,
+        lineHeight,
+        lineHighlightColor,
+        lineNumbers,
+        lineNumbersWidth,
+        removeBlurOnHover,
+        startingLineNumber,
+        tabSize,
+        theme,
+        useTabs,
+    } = attributes;
+
+    const fontFamilyRatio = (fontFamily: string) =>
+        fontFamily === 'Code-Pro-Fantasque-Sans-Mono' ? 0.5 : 0.6;
+
     // To add custom styles
     const themes = applyFilters(
         'blocks.codeBlockPro.themes',
         defaultThemes,
     ) as ThemeOption;
-    const styles = themes[attributes.theme]?.styles;
+    const styles = themes[theme]?.styles;
     return (
         <div
             {...blockProps.save({
                 className: classNames({
-                    'padding-disabled': attributes.disablePadding,
+                    'padding-disabled': disablePadding,
                     'padding-bottom-disabled':
-                        attributes?.footerType &&
-                        attributes?.footerType !== 'none',
-                    'cbp-has-line-numbers': attributes.lineNumbers,
-                    'cbp-blur-enabled': attributes.enableBlurring,
-                    'cbp-unblur-on-hover': attributes.removeBlurOnHover,
-                    'cbp-highlight-hover': attributes.highlightingHover,
+                        footerType && footerType !== 'none',
+                    'cbp-has-line-numbers': lineNumbers,
+                    'cbp-blur-enabled': enableBlurring,
+                    'cbp-unblur-on-hover': removeBlurOnHover,
+                    'cbp-highlight-hover': highlightingHover,
                 }),
             })}
-            data-code-block-pro-font-family={attributes.fontFamily}
+            data-code-block-pro-font-family={fontFamily}
             style={
                 {
-                    fontSize: maybeClamp(
-                        attributes.fontSize,
-                        attributes.clampFonts,
-                    ),
+                    fontSize: maybeClamp(fontSize, clampFonts),
                     // Tiny check to avoid block invalidation error
-                    fontFamily: fontFamilyLong(attributes.fontFamily),
-                    '--cbp-line-number-color': attributes?.lineNumbers
+                    fontFamily: fontFamilyLong(fontFamily),
+                    '--cbp-line-number-color': lineNumbers
                         ? findLineNumberColor(attributes)
                         : undefined,
                     '--cbp-line-number-start':
-                        Number(attributes?.startingLineNumber) > 1
-                            ? attributes.startingLineNumber
+                        Number(startingLineNumber) > 1
+                            ? startingLineNumber
                             : undefined,
-                    '--cbp-line-number-width': attributes.lineNumbersWidth
-                        ? `${attributes.lineNumbersWidth}px`
+                    '--cbp-line-number-width': highestLineNumber
+                        ? `calc(${
+                              String(highestLineNumber).length
+                          } * ${fontFamilyRatio(fontFamily)} * ${fontSize})`
+                        : lineNumbersWidth
+                        ? `${lineNumbersWidth}px`
                         : undefined,
                     '--cbp-line-highlight-color':
-                        attributes?.enableHighlighting ||
-                        attributes?.highlightingHover
-                            ? attributes.lineHighlightColor
+                        enableHighlighting || highlightingHover
+                            ? lineHighlightColor
                             : undefined,
-                    lineHeight: maybeClamp(
-                        attributes.lineHeight,
-                        attributes.clampFonts,
-                    ),
+                    lineHeight: maybeClamp(lineHeight, clampFonts),
                     '--cbp-tab-width':
-                        attributes.useTabs === undefined
+                        useTabs === undefined
                             ? undefined // bw compatibility
-                            : String(attributes.tabSize),
+                            : String(tabSize),
                     tabSize:
-                        attributes.useTabs === undefined
+                        useTabs === undefined
                             ? undefined // bw compatibility
                             : 'var(--cbp-tab-width, 2)',
                     ...Object.entries(styles ?? {}).reduce(
@@ -82,11 +104,11 @@ export const BlockOutput = ({ attributes }: { attributes: Attributes }) => {
                     ) as object),
                 } as React.CSSProperties
             }>
-            {attributes.code?.length > 0 ? (
+            {code?.length > 0 ? (
                 <>
                     <HeaderType {...attributes} />
                     <ButtonList {...attributes} />
-                    <RichText.Content value={attributes.codeHTML} />
+                    <RichText.Content value={codeHTML} />
                     <FooterType {...attributes} />
                     <SeeMoreType {...attributes} />
                 </>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -136,8 +136,8 @@ registerBlockType<Attributes>(blockConfig.name, {
                                     ? undefined // bw compatability
                                     : attributes.tabSize,
                             // Disabled as ligatures will break the editor line widths
-                            // fontFamily: fontFamilyLong(attributes.fontFamily),
-                            fontFamily: fontFamilyLong(''),
+                            fontFamily: fontFamilyLong(attributes.fontFamily),
+                            // fontFamily: fontFamilyLong(''),
                             lineHeight: maybeClamp(
                                 attributes.lineHeight,
                                 attributes.clampFonts,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -135,9 +135,7 @@ registerBlockType<Attributes>(blockConfig.name, {
                                 attributes.useTabs === undefined
                                     ? undefined // bw compatability
                                     : attributes.tabSize,
-                            // Disabled as ligatures will break the editor line widths
                             fontFamily: fontFamilyLong(attributes.fontFamily),
-                            // fontFamily: fontFamilyLong(''),
                             lineHeight: maybeClamp(
                                 attributes.lineHeight,
                                 attributes.clampFonts,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,7 @@ registerBlockType<Attributes>(blockConfig.name, {
         seeMoreTransition: { type: 'boolean' },
         startingLineNumber: { type: 'string' },
         lineNumbersWidth: { type: 'number' },
+        highestLineNumber: { type: 'number' },
         enableHighlighting: { type: 'boolean' },
         highlightingHover: { type: 'boolean' },
         lineHighlights: { type: 'string' },
@@ -76,6 +77,27 @@ registerBlockType<Attributes>(blockConfig.name, {
     },
     title: __('Code Pro', 'code-block-pro'),
     edit: ({ attributes, setAttributes }) => {
+        const {
+            clampFonts,
+            disablePadding,
+            enableBlurring,
+            enableHighlighting,
+            footerType,
+            fontSize,
+            fontFamily,
+            highestLineNumber,
+            highlightingHover,
+            lineHeight,
+            lineHighlightColor,
+            lineNumbers,
+            lineNumbersWidth,
+            removeBlurOnHover,
+            startingLineNumber,
+            tabSize,
+            theme,
+            useTabs,
+        } = attributes;
+
         // Restricts users without unfiltered HTML access
         const hasPermission = window.codeBlockPro.canSaveHtml;
         setAttributes = hasPermission ? setAttributes : () => undefined;
@@ -85,7 +107,7 @@ registerBlockType<Attributes>(blockConfig.name, {
             'blocks.codeBlockPro.themes',
             defaultThemes,
         ) as ThemeOption;
-        const styles = themes[attributes.theme]?.styles;
+        const styles = themes[theme]?.styles;
         return (
             <>
                 <SidebarControls
@@ -100,46 +122,41 @@ registerBlockType<Attributes>(blockConfig.name, {
                 <div
                     {...blockProps({
                         className: classnames('code-block-pro-editor', {
-                            'padding-disabled': attributes.disablePadding,
+                            'padding-disabled': disablePadding,
                             'padding-bottom-disabled':
-                                attributes?.footerType &&
-                                attributes?.footerType !== 'none',
-                            'cbp-has-line-numbers': attributes.lineNumbers,
-                            'cbp-blur-enabled': attributes.enableBlurring,
-                            'cbp-unblur-on-hover': attributes.removeBlurOnHover,
-                            'cbp-highlight-hover': attributes.highlightingHover,
+                                footerType && footerType !== 'none',
+                            'cbp-has-line-numbers': lineNumbers,
+                            'cbp-blur-enabled': enableBlurring,
+                            'cbp-unblur-on-hover': removeBlurOnHover,
+                            'cbp-highlight-hover': highlightingHover,
                         }),
                         style: {
-                            fontSize: maybeClamp(
-                                attributes.fontSize,
-                                attributes.clampFonts,
-                            ),
-                            '--cbp-line-number-color': attributes?.lineNumbers
+                            fontSize: maybeClamp(fontSize, clampFonts),
+                            '--cbp-line-number-color': lineNumbers
                                 ? findLineNumberColor(attributes)
                                 : undefined,
                             '--cbp-line-number-start':
-                                Number(attributes?.startingLineNumber) > 1
-                                    ? attributes.startingLineNumber
+                                Number(startingLineNumber) > 1
+                                    ? startingLineNumber
                                     : undefined,
-                            '--cbp-line-number-width':
-                                attributes.lineNumbersWidth
-                                    ? `${attributes.lineNumbersWidth}px`
-                                    : undefined,
+                            '--cbp-line-number-width': highestLineNumber
+                                ? `calc(${
+                                      String(highestLineNumber).length
+                                  } * ${fontSize})`
+                                : lineNumbersWidth
+                                ? `${lineNumbersWidth}px`
+                                : undefined,
                             '--cbp-line-highlight-color':
-                                attributes?.enableHighlighting ||
-                                attributes?.highlightingHover
-                                    ? attributes.lineHighlightColor
+                                enableHighlighting || highlightingHover
+                                    ? lineHighlightColor
                                     : undefined,
-                            '--cbp-line-height': attributes.lineHeight,
+                            '--cbp-line-height': lineHeight,
                             tabSize:
-                                attributes.useTabs === undefined
+                                useTabs === undefined
                                     ? undefined // bw compatability
-                                    : attributes.tabSize,
-                            fontFamily: fontFamilyLong(attributes.fontFamily),
-                            lineHeight: maybeClamp(
-                                attributes.lineHeight,
-                                attributes.clampFonts,
-                            ),
+                                    : tabSize,
+                            fontFamily: fontFamilyLong(fontFamily),
+                            lineHeight: maybeClamp(lineHeight, clampFonts),
                             ...Object.entries(styles ?? {}).reduce(
                                 (acc, [key, value]) => ({
                                     ...acc,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,10 @@ export type Attributes = {
     footerLinkTarget?: boolean;
     disablePadding: boolean;
     startingLineNumber: string;
+    // Defunct - Removing it would require n attribute migration
+    // so it's easier to just leave it unused for new blocks.
     lineNumbersWidth: number;
+    highestLineNumber: number;
     enableHighlighting: boolean;
     highlightingHover: boolean;
     lineHighlights: string;

--- a/src/util/fonts.ts
+++ b/src/util/fonts.ts
@@ -19,3 +19,11 @@ export const maybeClamp = (size: string, clampFonts: boolean) => {
         parseFloat(size) * 24
     }px)`;
 };
+
+export const getTextWidth = (text: string, font?: string) => {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    if (!context) return 0;
+    context.font = font || getComputedStyle(document.body).font;
+    return context.measureText(text).width;
+};


### PR DESCRIPTION
This updates how the line number are computed, using a simple formula (`fontSize` * `highestLineNumber` * `0.6` ratio) to estimate a "good enough" width.

Previously it would get the exact width, which fails when two users using differing zoom levels edit a post. Regardless, as was pointed out to me, it shouldn't be reliant on the font size of the user editing it, but the font size of the browser (and user viewing the page).