### PR TITLE
Update how unfiltered html is checked

### DIFF
--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -1,7 +1,7 @@
 name: Build production zip file
 on:
-  push:
-  workflow_dispatch:
+    push:
+    workflow_dispatch:
 jobs:
     build:
         name: Build zip file

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,6 +4,7 @@ module.exports = {
     semi: true,
     singleQuote: true,
     bracketSameLine: true,
+    plugins: ['@trivago/prettier-plugin-sort-imports'],
     importOrder: ['^@wordpress/(.*)$', '<THIRD_PARTY_MODULES>', '^[./]'],
     overrides: [
         {

--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -26,7 +26,6 @@ add_action('init', function () {
 add_action('admin_init', function () {
     wp_add_inline_script('kevinbatdorf-code-block-pro-editor-script', 'window.codeBlockPro = ' . wp_json_encode([
         'pluginUrl' => esc_url_raw(plugin_dir_url(__FILE__)),
-        'canSaveHtml' => current_user_can('unfiltered_html'),
     ]) . ';');
 });
 

--- a/cypress/e2e/permissions.cy.js
+++ b/cypress/e2e/permissions.cy.js
@@ -3,9 +3,6 @@ beforeEach(() => {
     cy.clearBrowserStorage();
     cy.loginUser();
     cy.visitNewPostEditor();
-    cy.window().then((win) => {
-        win.codeBlockPro.canSaveHtml = false;
-    });
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert

--- a/cypress/e2e/permissions.cy.js
+++ b/cypress/e2e/permissions.cy.js
@@ -1,6 +1,13 @@
 beforeEach(() => {
     cy.resetDatabase();
     cy.clearBrowserStorage();
+    cy.intercept(
+        'GET',
+        '/index.php?rest_route=%2Fcode-block-pro%2Fv1%2Fcan-save-html&_locale=user',
+        {
+            body: false,
+        },
+    ).as('canSaveHtml');
     cy.loginUser();
     cy.visitNewPostEditor();
 });
@@ -11,14 +18,17 @@ afterEach(() => {
 context('Permissions', () => {
     it('Warning shows when cap is missing', () => {
         cy.addBlock('kevinbatdorf/code-block-pro');
+        cy.wait('@canSaveHtml');
         cy.getPostContent('.wp-block[class$="code-block-pro"]')
             .invoke('html')
-            .should('contain', 'capability is required to edit this block');
+            .should('contain', 'capability is required');
     });
 
     it('Prevents updating attributes', () => {
         cy.addBlock('kevinbatdorf/code-block-pro');
         cy.openSideBarPanel('Line Settings');
+
+        cy.wait('@canSaveHtml');
 
         // ported from lines spec with the final assertions updated
         cy.get('[data-cy="show-line-numbers"]')

--- a/cypress/e2e/permissions.cy.js
+++ b/cypress/e2e/permissions.cy.js
@@ -26,24 +26,9 @@ context('Permissions', () => {
 
     it('Prevents updating attributes', () => {
         cy.addBlock('kevinbatdorf/code-block-pro');
-        cy.openSideBarPanel('Line Settings');
 
         cy.wait('@canSaveHtml');
 
-        // ported from lines spec with the final assertions updated
-        cy.get('[data-cy="show-line-numbers"]')
-            .should('exist')
-            .should('not.be.checked');
-        cy.getPostContent('.wp-block[class$="code-block-pro"]').should(
-            'not.have.class',
-            'cbp-has-line-numbers',
-        );
-
-        cy.get('[data-cy="show-line-numbers"]').check();
-        cy.get('[data-cy="show-line-numbers"]').should('be.checked');
-        cy.getPostContent('.wp-block[class$="code-block-pro"]').should(
-            'not.have.class', // changed here
-            'cbp-has-line-numbers',
-        );
+        cy.get('[data-cy="show-line-numbers"]').should('not.exist');
     });
 });

--- a/php/routes.php
+++ b/php/routes.php
@@ -26,4 +26,8 @@ add_action('rest_api_init', function () {
             ]
         );
     });
+
+    CBPRouter::get('/can-save-html', function () {
+        return new WP_REST_Response(current_user_can('unfiltered_html'));
+    });
 });

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -1,0 +1,112 @@
+import { useBlockProps as blockProps } from '@wordpress/block-editor';
+import { applyFilters } from '@wordpress/hooks';
+import classnames from 'classnames';
+import { Edit } from './editor/Edit';
+import { FooterType } from './editor/components/FooterSelect';
+import { HeaderType } from './editor/components/HeaderSelect';
+import { SeeMoreType } from './editor/components/SeeMoreSelect';
+import { ButtonList } from './editor/components/buttons/ButtonList';
+import { SidebarControls } from './editor/controls/Sidebar';
+import { ToolbarControls } from './editor/controls/Toolbar';
+import { findLineNumberColor } from './util/colors';
+import { fontFamilyLong, maybeClamp } from './util/fonts';
+import { AttributesPropsAndSetter } from './types';
+import defaultThemes from './defaultThemes.json';
+import { ThemeOption } from './types';
+import { useCanEditHTML } from './hooks/useCanEditHTML';
+
+export const Editor = ({
+    attributes,
+    setAttributes,
+}: AttributesPropsAndSetter) => {
+    // To add custom styles
+    const themes = applyFilters(
+        'blocks.codeBlockPro.themes',
+        defaultThemes,
+    ) as ThemeOption;
+    const styles = themes[attributes.theme]?.styles;
+    const hasPermission = useCanEditHTML();
+    setAttributes = hasPermission ? setAttributes : () => undefined;
+
+    return (
+        <>
+            <SidebarControls
+                attributes={attributes}
+                canEdit={!!hasPermission}
+                setAttributes={setAttributes}
+            />
+            <ToolbarControls
+                attributes={attributes}
+                setAttributes={setAttributes}
+            />
+            <div
+                {...blockProps({
+                    className: classnames('code-block-pro-editor', {
+                        'padding-disabled': attributes.disablePadding,
+                        'padding-bottom-disabled':
+                            attributes?.footerType &&
+                            attributes?.footerType !== 'none',
+                        'cbp-has-line-numbers': attributes.lineNumbers,
+                        'cbp-blur-enabled': attributes.enableBlurring,
+                        'cbp-unblur-on-hover': attributes.removeBlurOnHover,
+                        'cbp-highlight-hover': attributes.highlightingHover,
+                    }),
+                    style: {
+                        fontSize: maybeClamp(
+                            attributes.fontSize,
+                            attributes.clampFonts,
+                        ),
+                        '--cbp-line-number-color': attributes?.lineNumbers
+                            ? findLineNumberColor(attributes)
+                            : undefined,
+                        '--cbp-line-number-start':
+                            Number(attributes?.startingLineNumber) > 1
+                                ? attributes.startingLineNumber
+                                : undefined,
+                        '--cbp-line-number-width': attributes.lineNumbersWidth
+                            ? `${attributes.lineNumbersWidth}px`
+                            : undefined,
+                        '--cbp-line-highlight-color':
+                            attributes?.enableHighlighting ||
+                            attributes?.highlightingHover
+                                ? attributes.lineHighlightColor
+                                : undefined,
+                        '--cbp-line-height': attributes.lineHeight,
+                        tabSize:
+                            attributes.useTabs === undefined
+                                ? undefined // bw compatability
+                                : attributes.tabSize,
+                        // Disabled as ligatures will break the editor line widths
+                        // fontFamily: fontFamilyLong(attributes.fontFamily),
+                        fontFamily: fontFamilyLong(''),
+                        lineHeight: maybeClamp(
+                            attributes.lineHeight,
+                            attributes.clampFonts,
+                        ),
+                        ...Object.entries(styles ?? {}).reduce(
+                            (acc, [key, value]) => ({
+                                ...acc,
+                                [`--shiki-${key}`]: value,
+                            }),
+                            {},
+                        ),
+                        ...(applyFilters(
+                            'blocks.codeBlockPro.additionalEditorAttributes',
+                            {},
+                            attributes,
+                        ) as object),
+                    },
+                })}>
+                <HeaderType {...attributes} />
+                <ButtonList {...attributes} />
+                <Edit
+                    attributes={attributes}
+                    setAttributes={setAttributes}
+                    canEdit={!!hasPermission}
+                />
+                <FooterType {...attributes} />
+                <SeeMoreType {...attributes} />
+            </div>
+        </>
+    );
+};

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -1,6 +1,7 @@
 import { useBlockProps as blockProps } from '@wordpress/block-editor';
 import { applyFilters } from '@wordpress/hooks';
 import classnames from 'classnames';
+import defaultThemes from './defaultThemes.json';
 import { Edit } from './editor/Edit';
 import { FooterType } from './editor/components/FooterSelect';
 import { HeaderType } from './editor/components/HeaderSelect';
@@ -8,11 +9,10 @@ import { SeeMoreType } from './editor/components/SeeMoreSelect';
 import { ButtonList } from './editor/components/buttons/ButtonList';
 import { SidebarControls } from './editor/controls/Sidebar';
 import { ToolbarControls } from './editor/controls/Toolbar';
+import { AttributesPropsAndSetter } from './types';
+import { ThemeOption } from './types';
 import { findLineNumberColor } from './util/colors';
 import { fontFamilyLong, maybeClamp } from './util/fonts';
-import { AttributesPropsAndSetter } from './types';
-import defaultThemes from './defaultThemes.json';
-import { ThemeOption } from './types';
 
 export const Editor = ({
     attributes,
@@ -91,7 +91,7 @@ export const Editor = ({
                             useTabs === undefined
                                 ? undefined // bw compatability
                                 : tabSize,
-                        fontFamily: fontFamilyLong(''),
+                        fontFamily: fontFamilyLong(fontFamily),
                         lineHeight: maybeClamp(lineHeight, clampFonts),
                         ...Object.entries(styles ?? {}).reduce(
                             (acc, [key, value]) => ({

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -13,7 +13,6 @@ import { fontFamilyLong, maybeClamp } from './util/fonts';
 import { AttributesPropsAndSetter } from './types';
 import defaultThemes from './defaultThemes.json';
 import { ThemeOption } from './types';
-import { useCanEditHTML } from './hooks/useCanEditHTML';
 
 export const Editor = ({
     attributes,
@@ -25,14 +24,11 @@ export const Editor = ({
         defaultThemes,
     ) as ThemeOption;
     const styles = themes[attributes.theme]?.styles;
-    const hasPermission = useCanEditHTML();
-    setAttributes = hasPermission ? setAttributes : () => undefined;
 
     return (
         <>
             <SidebarControls
                 attributes={attributes}
-                canEdit={!!hasPermission}
                 setAttributes={setAttributes}
             />
             <ToolbarControls
@@ -99,11 +95,7 @@ export const Editor = ({
                 })}>
                 <HeaderType {...attributes} />
                 <ButtonList {...attributes} />
-                <Edit
-                    attributes={attributes}
-                    setAttributes={setAttributes}
-                    canEdit={!!hasPermission}
-                />
+                <Edit attributes={attributes} setAttributes={setAttributes} />
                 <FooterType {...attributes} />
                 <SeeMoreType {...attributes} />
             </div>

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -10,16 +10,16 @@ import { applyFilters } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { sprintf, __ } from '@wordpress/i18n';
 import Editor from 'react-simple-code-editor';
+import { useCanEditHTML } from '../hooks/useCanEditHTML';
 import { useDefaults } from '../hooks/useDefaults';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguageStore } from '../state/language';
 import { AttributesPropsAndSetter, Lang } from '../types';
 import { parseJSONArrayWithRanges } from '../util/arrayHelpers';
 import { computeLineHighlightColor } from '../util/colors';
+import { getTextWidth } from '../util/fonts';
 import { getEditorLanguage } from '../util/languages';
 import { MissingPermissionsTip } from './components/misc/MissingPermissions';
-import { useCanEditHTML } from '../hooks/useCanEditHTML';
-import { getTextWidth } from '../util/fonts';
 
 export const Edit = ({
     attributes,

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -17,12 +17,12 @@ import { parseJSONArrayWithRanges } from '../util/arrayHelpers';
 import { computeLineHighlightColor } from '../util/colors';
 import { getEditorLanguage } from '../util/languages';
 import { MissingPermissionsTip } from './components/misc/MissingPermissions';
+import { useCanEditHTML } from '../hooks/useCanEditHTML';
 
 export const Edit = ({
     attributes,
     setAttributes,
-    canEdit,
-}: AttributesPropsAndSetter & { canEdit: boolean }) => {
+}: AttributesPropsAndSetter) => {
     const {
         language,
         theme,
@@ -51,6 +51,7 @@ export const Edit = ({
     } = attributes;
 
     const textAreaRef = useRef<HTMLDivElement>(null);
+    const canEdit = useCanEditHTML();
     const handleChange = (code: string) =>
         setAttributes({ code: encode(code) });
     const { previousLanguage } = useLanguageStore();
@@ -115,7 +116,7 @@ export const Edit = ({
             bgColor: highlighter.getBackgroundColor(),
             textColor: highlighter.getForegroundColor(),
         });
-    }, [theme, highlighter, setAttributes]);
+    }, [theme, highlighter, setAttributes, canEdit]);
 
     useEffect(() => {
         if (!highlighter) return;
@@ -150,6 +151,7 @@ export const Edit = ({
         highlighter,
         seeMoreAfterLine,
         seeMoreTransition,
+        canEdit,
         color,
         code,
         enableMaxHeight,
@@ -193,6 +195,7 @@ export const Edit = ({
         startingLineNumber,
         code,
         loading,
+        canEdit,
         error,
         textAreaRef,
         setAttributes,
@@ -226,6 +229,8 @@ export const Edit = ({
             </div>
         );
     }
+
+    if (canEdit === undefined) return null;
 
     return (
         <div

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -237,7 +237,7 @@ export const Edit = ({
                 overflow: Number(editorHeight) ? 'auto' : undefined,
             }}>
             {canEdit ? null : (
-                <div className="absolute inset-0 z-10 bg-white bg-opacity-70">
+                <div className="absolute inset-0 z-10">
                     <MissingPermissionsTip />
                 </div>
             )}

--- a/src/editor/components/misc/MissingPermissions.tsx
+++ b/src/editor/components/misc/MissingPermissions.tsx
@@ -10,7 +10,7 @@ export const MissingPermissionsTip = () => (
                     dangerouslySetInnerHTML={{
                         __html: sprintf(
                             __(
-                                'The %s capability is required to edit this block. Contact an admin to enable this feature. This is not an error.',
+                                'Read-only mode: The %s capability is required.',
                                 'code-block-pro',
                             ),
                             '<code>unfiltered_html</code>',

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -32,12 +32,12 @@ import { ThemesPanel } from '../components/ThemesPanel';
 import { MissingPermissionsTip } from '../components/misc/MissingPermissions';
 import { BlurControl } from './BlurControl';
 import { HighlightingControl } from './HighlightingControl';
+import { useCanEditHTML } from '../../hooks/useCanEditHTML';
 
 export const SidebarControls = ({
     attributes,
     setAttributes,
-    canEdit,
-}: AttributesPropsAndSetter & { canEdit: boolean }) => {
+}: AttributesPropsAndSetter) => {
     const [language, setLanguage] = useLanguage({ attributes, setAttributes });
     const { recentLanguages } = useLanguageStore();
     const { updateThemeHistory } = useThemeStore();
@@ -46,9 +46,8 @@ export const SidebarControls = ({
     const languagesSorted = new Map(
         Object.entries(languages).sort((a, b) => a[1].localeCompare(b[1])),
     );
-
+    const canEdit = useCanEditHTML();
     const footersNeedingLinks = ['simpleStringEnd', 'simpleStringStart'];
-
     const showHeaderTextEdit = [
         'simpleString',
         'pillString',
@@ -71,9 +70,15 @@ export const SidebarControls = ({
         });
     }, [bringAttentionToPanel, closeGeneralSidebar, openGeneralSidebar]);
 
+    if (!canEdit)
+        return (
+            <InspectorControls>
+                {canEdit ? null : <MissingPermissionsTip />}
+            </InspectorControls>
+        );
+
     return (
         <InspectorControls>
-            {canEdit ? null : <MissingPermissionsTip />}
             <PanelBody
                 title={__('Language', 'code-block-pro')}
                 initialOpen={bringAttention === 'language-select'}>

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -13,6 +13,7 @@ import { useDispatch } from '@wordpress/data';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useCanEditHTML } from '../../hooks/useCanEditHTML';
 import { useLanguage } from '../../hooks/useLanguage';
 import { useGlobalStore } from '../../state/global';
 import { useLanguageStore } from '../../state/language';
@@ -32,7 +33,6 @@ import { ThemesPanel } from '../components/ThemesPanel';
 import { MissingPermissionsTip } from '../components/misc/MissingPermissions';
 import { BlurControl } from './BlurControl';
 import { HighlightingControl } from './HighlightingControl';
-import { useCanEditHTML } from '../../hooks/useCanEditHTML';
 
 export const SidebarControls = ({
     attributes,

--- a/src/editor/controls/Toolbar.tsx
+++ b/src/editor/controls/Toolbar.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '../../hooks/useLanguage';
 import { useGlobalStore } from '../../state/global';
 import { AttributesPropsAndSetter, ThemeOption } from '../../types';
 import { languages } from '../../util/languages';
+import { useCanEditHTML } from '../../hooks/useCanEditHTML';
 
 export const ToolbarControls = ({
     attributes,
@@ -19,6 +20,9 @@ export const ToolbarControls = ({
         defaultThemes,
     ) as ThemeOption;
     const { setBringAttentionToPanel } = useGlobalStore();
+    const canEdit = useCanEditHTML();
+
+    if (canEdit === undefined) return null;
 
     return (
         <BlockControls>

--- a/src/editor/controls/Toolbar.tsx
+++ b/src/editor/controls/Toolbar.tsx
@@ -3,11 +3,11 @@ import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import defaultThemes from '../../defaultThemes.json';
+import { useCanEditHTML } from '../../hooks/useCanEditHTML';
 import { useLanguage } from '../../hooks/useLanguage';
 import { useGlobalStore } from '../../state/global';
 import { AttributesPropsAndSetter, ThemeOption } from '../../types';
 import { languages } from '../../util/languages';
-import { useCanEditHTML } from '../../hooks/useCanEditHTML';
 
 export const ToolbarControls = ({
     attributes,

--- a/src/hooks/useCanEditHTML.ts
+++ b/src/hooks/useCanEditHTML.ts
@@ -1,0 +1,12 @@
+import useSWRImmutable from 'swr/immutable';
+import apiFetch from '@wordpress/api-fetch';
+
+const fetcher = (url: string) => apiFetch({ path: url });
+
+export const useCanEditHTML = () => {
+    const { data } = useSWRImmutable(
+        '/code-block-pro/v1/can-save-html',
+        fetcher,
+    );
+    return data;
+};

--- a/src/hooks/useCanEditHTML.ts
+++ b/src/hooks/useCanEditHTML.ts
@@ -1,12 +1,13 @@
 import useSWRImmutable from 'swr/immutable';
 import apiFetch from '@wordpress/api-fetch';
 
-const fetcher = (url: string) => apiFetch({ path: url });
+const fetcher = (url: string) => apiFetch<boolean>({ path: url });
 
 export const useCanEditHTML = () => {
-    const { data } = useSWRImmutable(
+    const { data } = useSWRImmutable<boolean>(
         '/code-block-pro/v1/can-save-html',
         fetcher,
     );
+    // Consider it true until the request completes
     return data;
 };

--- a/src/hooks/useCanEditHTML.ts
+++ b/src/hooks/useCanEditHTML.ts
@@ -1,5 +1,5 @@
-import useSWRImmutable from 'swr/immutable';
 import apiFetch from '@wordpress/api-fetch';
+import useSWRImmutable from 'swr/immutable';
 
 const fetcher = (url: string) => apiFetch<boolean>({ path: url });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
+import { Editor } from './Editor';
 import blockConfig from './block.json';
 import { BlockFilter } from './editor/components/BlockFilter';
 import './editor/editor.css';
@@ -8,7 +9,6 @@ import { transformToCBP, transformFromCBP } from './editor/transforms';
 import { BlockOutput } from './front/BlockOutput';
 import { blockIcon } from './icons';
 import { Attributes } from './types';
-import { Editor } from './Editor';
 
 registerBlockType<Attributes>(blockConfig.name, {
     ...blockConfig,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,25 +1,14 @@
-import { useBlockProps as blockProps } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
-import { addFilter, applyFilters } from '@wordpress/hooks';
+import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
-import classnames from 'classnames';
 import blockConfig from './block.json';
-import defaultThemes from './defaultThemes.json';
-import { Edit } from './editor/Edit';
 import { BlockFilter } from './editor/components/BlockFilter';
-import { FooterType } from './editor/components/FooterSelect';
-import { HeaderType } from './editor/components/HeaderSelect';
-import { SeeMoreType } from './editor/components/SeeMoreSelect';
-import { ButtonList } from './editor/components/buttons/ButtonList';
-import { SidebarControls } from './editor/controls/Sidebar';
-import { ToolbarControls } from './editor/controls/Toolbar';
 import './editor/editor.css';
 import { transformToCBP, transformFromCBP } from './editor/transforms';
 import { BlockOutput } from './front/BlockOutput';
 import { blockIcon } from './icons';
-import { Attributes, ThemeOption } from './types';
-import { findLineNumberColor } from './util/colors';
-import { fontFamilyLong, maybeClamp } from './util/fonts';
+import { Attributes } from './types';
+import { Editor } from './Editor';
 
 registerBlockType<Attributes>(blockConfig.name, {
     ...blockConfig,
@@ -75,100 +64,9 @@ registerBlockType<Attributes>(blockConfig.name, {
         align: ['wide', 'full'],
     },
     title: __('Code Pro', 'code-block-pro'),
-    edit: ({ attributes, setAttributes }) => {
-        // Restricts users without unfiltered HTML access
-        const hasPermission = window.codeBlockPro.canSaveHtml;
-        setAttributes = hasPermission ? setAttributes : () => undefined;
-
-        // To add custom styles
-        const themes = applyFilters(
-            'blocks.codeBlockPro.themes',
-            defaultThemes,
-        ) as ThemeOption;
-        const styles = themes[attributes.theme]?.styles;
-        return (
-            <>
-                <SidebarControls
-                    attributes={attributes}
-                    canEdit={hasPermission}
-                    setAttributes={setAttributes}
-                />
-                <ToolbarControls
-                    attributes={attributes}
-                    setAttributes={setAttributes}
-                />
-                <div
-                    {...blockProps({
-                        className: classnames('code-block-pro-editor', {
-                            'padding-disabled': attributes.disablePadding,
-                            'padding-bottom-disabled':
-                                attributes?.footerType &&
-                                attributes?.footerType !== 'none',
-                            'cbp-has-line-numbers': attributes.lineNumbers,
-                            'cbp-blur-enabled': attributes.enableBlurring,
-                            'cbp-unblur-on-hover': attributes.removeBlurOnHover,
-                            'cbp-highlight-hover': attributes.highlightingHover,
-                        }),
-                        style: {
-                            fontSize: maybeClamp(
-                                attributes.fontSize,
-                                attributes.clampFonts,
-                            ),
-                            '--cbp-line-number-color': attributes?.lineNumbers
-                                ? findLineNumberColor(attributes)
-                                : undefined,
-                            '--cbp-line-number-start':
-                                Number(attributes?.startingLineNumber) > 1
-                                    ? attributes.startingLineNumber
-                                    : undefined,
-                            '--cbp-line-number-width':
-                                attributes.lineNumbersWidth
-                                    ? `${attributes.lineNumbersWidth}px`
-                                    : undefined,
-                            '--cbp-line-highlight-color':
-                                attributes?.enableHighlighting ||
-                                attributes?.highlightingHover
-                                    ? attributes.lineHighlightColor
-                                    : undefined,
-                            '--cbp-line-height': attributes.lineHeight,
-                            tabSize:
-                                attributes.useTabs === undefined
-                                    ? undefined // bw compatability
-                                    : attributes.tabSize,
-                            // Disabled as ligatures will break the editor line widths
-                            // fontFamily: fontFamilyLong(attributes.fontFamily),
-                            fontFamily: fontFamilyLong(''),
-                            lineHeight: maybeClamp(
-                                attributes.lineHeight,
-                                attributes.clampFonts,
-                            ),
-                            ...Object.entries(styles ?? {}).reduce(
-                                (acc, [key, value]) => ({
-                                    ...acc,
-                                    [`--shiki-${key}`]: value,
-                                }),
-                                {},
-                            ),
-                            ...(applyFilters(
-                                'blocks.codeBlockPro.additionalEditorAttributes',
-                                {},
-                                attributes,
-                            ) as object),
-                        },
-                    })}>
-                    <HeaderType {...attributes} />
-                    <ButtonList {...attributes} />
-                    <Edit
-                        attributes={attributes}
-                        setAttributes={setAttributes}
-                        canEdit={hasPermission}
-                    />
-                    <FooterType {...attributes} />
-                    <SeeMoreType {...attributes} />
-                </div>
-            </>
-        );
-    },
+    edit: ({ attributes, setAttributes }) => (
+        <Editor attributes={attributes} setAttributes={setAttributes} />
+    ),
     save: ({ attributes }) => <BlockOutput attributes={attributes} />,
     transforms: {
         from: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,6 @@ declare global {
     interface Window {
         codeBlockPro: {
             pluginUrl: string;
-            canSaveHtml: boolean;
         };
     }
 }

--- a/src/util/languages.ts
+++ b/src/util/languages.ts
@@ -64,14 +64,17 @@ export const removeAliases = (
     langs: typeof defaultLanguages,
 ): Partial<typeof defaultLanguages> => {
     const aliasesToRemove = Object.values(codeAliases).flat();
-    return Object.keys(langs).reduce((acc, key) => {
-        if (!aliasesToRemove.includes(key)) {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            acc[key as Lang] = langs[key as Lang];
-        }
-        return acc;
-    }, {} as Partial<typeof defaultLanguages>);
+    return Object.keys(langs).reduce(
+        (acc, key) => {
+            if (!aliasesToRemove.includes(key)) {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                acc[key as Lang] = langs[key as Lang];
+            }
+            return acc;
+        },
+        {} as Partial<typeof defaultLanguages>,
+    );
 };
 
 export const languages = removeAliases(defaultLanguages);


### PR DESCRIPTION
This updates how the unfiltered html cap is checked, hopefully resolving odd conflicts some users have been reporting. 

Includes a component refactor to allow the react hook

User reports:
https://github.com/KevinBatdorf/code-block-pro/issues/235
https://wordpress.org/support/topic/unfiltered_html-issue/