### PR TITLE
GitHub/Gist code fetching & automatic highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ cypress/videos/**/*
 !cypress/videos/**/.gitkeep
 cypress/downloads/**/*
 cypress/downloads/**/.gitkeep
+
+# IDE files
+.idea/

--- a/php/router.php
+++ b/php/router.php
@@ -36,6 +36,21 @@ if (!class_exists('CBPRouter')) {
             );
         }
 
+        public function codeHandler($namespace, $endpoint, $callback)
+        {
+            \register_rest_route(
+                $namespace,
+                $endpoint,
+                [
+                    'methods' => 'POST',
+                    'callback' => $callback,
+                    'permission_callback' => function () {
+                        return \current_user_can($this->capability);
+                    },
+                ]
+            );
+        }
+
         public static function __callStatic($name, array $arguments)
         {
             $name = "{$name}Handler";

--- a/php/router.php
+++ b/php/router.php
@@ -36,21 +36,6 @@ if (!class_exists('CBPRouter')) {
             );
         }
 
-        public function codeHandler($namespace, $endpoint, $callback)
-        {
-            \register_rest_route(
-                $namespace,
-                $endpoint,
-                [
-                    'methods' => 'POST',
-                    'callback' => $callback,
-                    'permission_callback' => function () {
-                        return \current_user_can($this->capability);
-                    },
-                ]
-            );
-        }
-
         public static function __callStatic($name, array $arguments)
         {
             $name = "{$name}Handler";

--- a/php/routes.php
+++ b/php/routes.php
@@ -31,8 +31,8 @@ add_action('rest_api_init', function () {
         return new WP_REST_Response(current_user_can('unfiltered_html'));
     });
 
-    CBPRouter::code('/code', function ($payload) {
-        $parsedUrl = wp_parse_url($payload['url']);
+    CBPRouter::get('/code', function (WP_REST_Request $request) {
+        $parsedUrl = wp_parse_url($request->get_param('url'));
 
         $validHosts = ['gist.githubusercontent.com', 'raw.githubusercontent.com', 'github.com'];
 

--- a/php/routes.php
+++ b/php/routes.php
@@ -39,7 +39,7 @@ add_action('rest_api_init', function () {
         if (!in_array($parsedUrl['host'], $validHosts)) {
             return new WP_REST_Response([
                 'message' => __('Invalid URL')
-            ]);
+            ], 400);
         }
 
         if ($parsedUrl['host'] === 'github.com') {
@@ -53,7 +53,7 @@ add_action('rest_api_init', function () {
         if ($response['headers']['content-type'] !== 'text/plain; charset=utf-8') {
             return new WP_REST_Response([
                 'message' => __('Invalid Content-Type')
-            ]);
+            ], 415);
         }
 
         return new WP_REST_Response([

--- a/php/routes.php
+++ b/php/routes.php
@@ -38,7 +38,7 @@ add_action('rest_api_init', function () {
 
         if (!in_array($parsedUrl['host'], $validHosts)) {
             return new WP_REST_Response([
-                'message' => 'Invalid URL'
+                'message' => __('Invalid URL')
             ]);
         }
 
@@ -52,7 +52,7 @@ add_action('rest_api_init', function () {
 
         if ($response['headers']['content-type'] !== 'text/plain; charset=utf-8') {
             return new WP_REST_Response([
-                'message' => 'Invalid Content-Type'
+                'message' => __('Invalid Content-Type')
             ]);
         }
 

--- a/php/routes.php
+++ b/php/routes.php
@@ -26,4 +26,32 @@ add_action('rest_api_init', function () {
             ]
         );
     });
+
+    CBPRouter::code('/code', function ($payload) {
+        $parsedUrl = wp_parse_url($payload['url']);
+
+        if ($parsedUrl['host'] !== 'gist.githubusercontent.com' && $parsedUrl['host'] !== 'raw.githubusercontent.com') {
+            return new WP_REST_Response(
+                [
+                    'code' => 'Error: Invalid Host'
+                ]
+            );
+        }
+
+        $response = wp_remote_get($payload['url']);
+
+        if ($response['headers']['content-type'] !== 'text/plain; charset=utf-8') {
+            return new WP_REST_Response(
+                [
+                    'code' => 'Error: Invalid Content-Type'
+                ]
+            );
+        }
+
+        return new WP_REST_Response(
+            [
+                'code' => $response['body']
+            ]
+        );
+    });
 });

--- a/php/routes.php
+++ b/php/routes.php
@@ -30,12 +30,22 @@ add_action('rest_api_init', function () {
     CBPRouter::code('/code', function ($payload) {
         $parsedUrl = wp_parse_url($payload['url']);
 
-        if ($parsedUrl['host'] !== 'gist.githubusercontent.com' && $parsedUrl['host'] !== 'raw.githubusercontent.com') {
+        if (
+            $parsedUrl['host'] !== 'gist.githubusercontent.com' &&
+            $parsedUrl['host'] !== 'raw.githubusercontent.com' &&
+            $parsedUrl['host'] !== 'github.com'
+        ) {
             return new WP_REST_Response(
                 [
                     'code' => 'Error: Invalid Host'
                 ]
             );
+        }
+
+        if ($parsedUrl['host'] === 'github.com') {
+            $parsedUrl['host'] = 'raw.githubusercontent.com';
+            $parsedUrl['path'] = str_replace('/blob', '', $parsedUrl['path']);
+            $payload['url'] = $parsedUrl['scheme'] . '://' . $parsedUrl['host'] . $parsedUrl['path'];
         }
 
         $response = wp_remote_get($payload['url']);

--- a/php/routes.php
+++ b/php/routes.php
@@ -30,11 +30,9 @@ add_action('rest_api_init', function () {
     CBPRouter::code('/code', function ($payload) {
         $parsedUrl = wp_parse_url($payload['url']);
 
-        $isValidHost = $parsedUrl['host'] === 'gist.githubusercontent.com' ||
-            $parsedUrl['host'] === 'raw.githubusercontent.com' ||
-            $parsedUrl['host'] === 'github.com';
+        $validHosts = ['gist.githubusercontent.com', 'raw.githubusercontent.com', 'github.com'];
 
-        if (!$isValidHost) {
+        if (!in_array($parsedUrl['host'], $validHosts)) {
             return new WP_REST_Response(
                 [
                     'code' => 'Error: Invalid Host'

--- a/php/routes.php
+++ b/php/routes.php
@@ -30,11 +30,11 @@ add_action('rest_api_init', function () {
     CBPRouter::code('/code', function ($payload) {
         $parsedUrl = wp_parse_url($payload['url']);
 
-        if (
-            $parsedUrl['host'] !== 'gist.githubusercontent.com' &&
+        $isValidHost = $parsedUrl['host'] !== 'gist.githubusercontent.com' &&
             $parsedUrl['host'] !== 'raw.githubusercontent.com' &&
-            $parsedUrl['host'] !== 'github.com'
-        ) {
+            $parsedUrl['host'] !== 'github.com';
+
+        if (!$isValidHost) {
             return new WP_REST_Response(
                 [
                     'code' => 'Error: Invalid Host'

--- a/php/routes.php
+++ b/php/routes.php
@@ -30,9 +30,9 @@ add_action('rest_api_init', function () {
     CBPRouter::code('/code', function ($payload) {
         $parsedUrl = wp_parse_url($payload['url']);
 
-        $isValidHost = $parsedUrl['host'] !== 'gist.githubusercontent.com' &&
-            $parsedUrl['host'] !== 'raw.githubusercontent.com' &&
-            $parsedUrl['host'] !== 'github.com';
+        $isValidHost = $parsedUrl['host'] === 'gist.githubusercontent.com' ||
+            $parsedUrl['host'] === 'raw.githubusercontent.com' ||
+            $parsedUrl['host'] === 'github.com';
 
         if (!$isValidHost) {
             return new WP_REST_Response(

--- a/php/routes.php
+++ b/php/routes.php
@@ -37,11 +37,9 @@ add_action('rest_api_init', function () {
         $validHosts = ['gist.githubusercontent.com', 'raw.githubusercontent.com', 'github.com'];
 
         if (!in_array($parsedUrl['host'], $validHosts)) {
-            return new WP_REST_Response(
-                [
-                    'code' => 'Error: Invalid Host'
-                ]
-            );
+            return new WP_REST_Response([
+                'message' => 'Invalid URL'
+            ]);
         }
 
         if ($parsedUrl['host'] === 'github.com') {
@@ -53,17 +51,13 @@ add_action('rest_api_init', function () {
         $response = wp_remote_get($payload['url']);
 
         if ($response['headers']['content-type'] !== 'text/plain; charset=utf-8') {
-            return new WP_REST_Response(
-                [
-                    'code' => 'Error: Invalid Content-Type'
-                ]
-            );
+            return new WP_REST_Response([
+                'message' => 'Invalid Content-Type'
+            ]);
         }
 
-        return new WP_REST_Response(
-            [
-                'code' => $response['body']
-            ]
-        );
+        return new WP_REST_Response([
+            'code' => $response['body']
+        ]);
     });
 });

--- a/php/routes.php
+++ b/php/routes.php
@@ -57,7 +57,7 @@ add_action('rest_api_init', function () {
         }
 
         return new WP_REST_Response([
-            'code' => $response['body']
+            'code' => wp_remote_retrieve_body($response)
         ]);
     });
 });

--- a/src/block.json
+++ b/src/block.json
@@ -46,7 +46,8 @@
         "label": { "type": "string", "default": "" },
         "copyButton": { "type": "boolean" },
         "tabSize": { "type": "number" },
-        "useTabs": { "type": "boolean" }
+        "useTabs": { "type": "boolean" },
+        "url": { "type": "string" }
     },
     "supports": {
         "html": false,

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -47,7 +47,7 @@ export const Edit = ({
         useDecodeURI,
         tabSize,
         useTabs,
-        url,
+        remoteCodeRepositoryUrl,
     } = attributes;
 
     const textAreaRef = useRef<HTMLDivElement>(null);
@@ -166,7 +166,7 @@ export const Edit = ({
         getBlurs,
         getHighlights,
         decode,
-        url
+        remoteCodeRepositoryUrl
     ]);
 
     useLayoutEffect(() => {

--- a/src/editor/Edit.tsx
+++ b/src/editor/Edit.tsx
@@ -48,6 +48,7 @@ export const Edit = ({
         useDecodeURI,
         tabSize,
         useTabs,
+        url,
     } = attributes;
 
     const textAreaRef = useRef<HTMLDivElement>(null);
@@ -162,6 +163,7 @@ export const Edit = ({
         getBlurs,
         getHighlights,
         decode,
+        url
     ]);
 
     useLayoutEffect(() => {

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -1,0 +1,57 @@
+import {BaseControl, TextControl,} from '@wordpress/components';
+import {useEffect, useRef} from '@wordpress/element';
+import {__} from '@wordpress/i18n';
+
+interface GitHubRepositoryControlProps {
+    value: string;
+    onChange: (value: string) => void;
+}
+
+export const GitHubRepositoryControl = ({value, onChange}: GitHubRepositoryControlProps) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (isValidUrl(value)) {
+            inputRef.current
+                ?.querySelector('input')
+                ?.classList.remove('cbp-input-error');
+        } else {
+            inputRef.current
+                ?.querySelector('input')
+                ?.classList.add('cbp-input-error');
+        }
+    }, [value]);
+    return (
+        <BaseControl id="code-block-pro-show-highlighting">
+            <div ref={inputRef}>
+                <TextControl
+                    spellCheck={false}
+                    autoComplete="off"
+                    type="text"
+                    data-cy="github-repository-link"
+                    label={__('Github Repository Link', 'code-block-pro')}
+                    help={__(
+                        'The link to your file. Supports raw.githubusercontent.com links.',
+                        'code-block-pro',
+                    )}
+                    value={value}
+                    onChange={onChange}
+                />
+            </div>
+        </BaseControl>
+    );
+};
+
+function isValidUrl(str: string) {
+    try {
+        const url = new URL(str);
+
+        if (url.host !== 'raw.githubusercontent.com') {
+            return false;
+        }
+    } catch (e) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -47,7 +47,7 @@ export const GitHubRepositoryControl = ({value, onChange, onCodeFetched}: GitHub
                 data-cy="github-repository-link"
                 label={__('Github Repository Link', 'code-block-pro')}
                 help={__(
-                    'The link to your file. Supports github.com links, gists, and raw content links.',
+                    'The link to your file. Supports GitHub links and gists.',
                     'code-block-pro',
                 )}
                 value={value}

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -58,14 +58,12 @@ function isValidUrl(str: string) {
     try {
         const url = new URL(str);
 
-        if (url.host !== 'raw.githubusercontent.com' && url.host !== 'github.com') {
-            return false;
-        }
+        return url.host === 'raw.githubusercontent.com' ||
+            url.host === 'gist.githubusercontent.com' ||
+            url.host === 'github.com';
     } catch (e) {
         return false;
     }
-
-    return true;
 }
 
 async function fetchFile(url: string) {

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -14,7 +14,7 @@ export const GitHubRepositoryControl = ({
     setAttributes,
 }: GitHubRepositoryControlProps) => {
     const inputRef = useRef<HTMLInputElement>(null);
-    const { code, isLoading, error, mutate } = useRemoteCodeFetching(remoteCodeRepositoryUrl);
+    const { code, loading, error, mutate } = useRemoteCodeFetching(remoteCodeRepositoryUrl);
 
     // Determines line highlighting from the URL
     useEffect(() => {
@@ -38,10 +38,10 @@ export const GitHubRepositoryControl = ({
 
     // Sets the code to the remotely fetched code
     useEffect(() => {
-        if (isLoading || error) return;
+        if (loading || error) return;
 
         setAttributes({ code: code });
-    }, [code, isLoading, error]);
+    }, [code, loading, error]);
 
     return (
         <BaseControl id="code-block-pro-remote-repository">

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -2,7 +2,7 @@ import {BaseControl, Button, TextControl,} from '@wordpress/components';
 import {useRef} from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 
 interface GitHubRepositoryControlProps {
     value: string;
@@ -58,13 +58,7 @@ export const GitHubRepositoryControl = ({value, onChange, onCodeFetched}: GitHub
                     data-cy="manage-themes"
                     variant="secondary"
                     isSmall
-                    onClick={() => fetchFile(value).then((code) => {
-                        if (value.indexOf("#L")) {
-                            onCodeFetched({code, lineNumbers: extractLineNumbers(value)});
-                        } else {
-                            onCodeFetched({code});
-                        }
-                    })}>
+                    onClick={() => mutate(value)}>
                     {__('Fetch Code', 'code-block-pro')}
                 </Button>
             )}

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -38,7 +38,7 @@ export const GitHubRepositoryControl = ({value, onChange, onCodeFetched}: GitHub
     }
 
     return (
-        <BaseControl id="code-block-pro-show-highlighting">
+        <BaseControl id="code-block-pro-remote-repository">
             <TextControl
                 ref={inputRef}
                 spellCheck={false}

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -47,7 +47,7 @@ export const GitHubRepositoryControl = ({
                 autoComplete="off"
                 type="text"
                 data-cy="github-repository-link"
-                label={__('Github Repository Link', 'code-block-pro')}
+                label={__('Github', 'code-block-pro')}
                 help={
                     error ?
                         <p style={{ color: 'red'}}>{__(error, 'code-block-pro')}</p> :

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -34,7 +34,7 @@ export const GitHubRepositoryControl = ({
                 setAttributes({ enableHighlighting: false, lineHighlights: '' });
             }
         }
-    }, [remoteCodeRepositoryUrl, code]);
+    }, [remoteCodeRepositoryUrl]);
 
     // Sets the code to the remotely fetched code
     useEffect(() => {

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -109,9 +109,8 @@ function getLineNumberFromToken(token: string) {
 
 async function fetchFile(url: string) {
     const response = await apiFetch({
-        path: 'code-block-pro/v1/code',
+        path: `code-block-pro/v1/code?url=${encodeURIComponent(url)}`,
         method: 'GET',
-        data: {url},
     });
 
     return response.code;

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -41,17 +41,15 @@ export const GitHubRepositoryControl = ({value, onChange, onCodeFetched}: GitHub
                     onChange={onChange}
                 />
             </div>
-            {
-                isValidUrl(value) ?
-                    <Button
-                        data-cy="manage-themes"
-                        variant="secondary"
-                        isSmall
-                        onClick={() => fetchFile(value).then(onCodeFetched)}>
-                        {__('Fetch Code', 'code-block-pro')}
-                    </Button> :
-                    null
-            }
+            {isValidUrl(value) && (
+                <Button
+                    data-cy="manage-themes"
+                    variant="secondary"
+                    isSmall
+                    onClick={() => fetchFile(value).then(onCodeFetched)}>
+                    {__('Fetch Code', 'code-block-pro')}
+                </Button>
+            )}
         </BaseControl>
     );
 };

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -18,10 +18,6 @@ export const GitHubRepositoryControl = ({
 
     // Determines line highlighting from the URL
     useEffect(() => {
-        isValidUrl(remoteCodeRepositoryUrl) ?
-            inputRef.current?.classList.remove('cbp-input-error') :
-            inputRef.current?.classList.add('cbp-input-error');
-
         if (remoteCodeRepositoryUrl.indexOf('#L')) {
             const lineNumbers = extractLineNumbers(remoteCodeRepositoryUrl);
 
@@ -52,10 +48,11 @@ export const GitHubRepositoryControl = ({
                 type="text"
                 data-cy="github-repository-link"
                 label={__('Github Repository Link', 'code-block-pro')}
-                help={__(
-                    'The link to your file. Supports GitHub links and gists.',
-                    'code-block-pro',
-                )}
+                help={
+                    error ?
+                        <p style={{ color: 'red'}}>{__(error, 'code-block-pro')}</p> :
+                        <p>{__('The link to your file. Supports GitHub links and gists.', 'code-block-pro')}</p>
+                }
                 value={remoteCodeRepositoryUrl}
                 onChange={(value) => setAttributes({ remoteCodeRepositoryUrl: value })}
             />

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -1,4 +1,4 @@
-import {BaseControl, TextControl,} from '@wordpress/components';
+import {BaseControl, Button, TextControl,} from '@wordpress/components';
 import {useEffect, useRef} from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
@@ -13,9 +13,7 @@ export const GitHubRepositoryControl = ({value, onChange, onCodeFetched}: GitHub
 
     useEffect(() => {
         if (isValidUrl(value)) {
-            fetchFile(value).then((code) => {
-                onCodeFetched(code);
-            });
+            fetchFile(value).then(onCodeFetched);
 
             inputRef.current
                 ?.querySelector('input')
@@ -43,6 +41,17 @@ export const GitHubRepositoryControl = ({value, onChange, onCodeFetched}: GitHub
                     onChange={onChange}
                 />
             </div>
+            {
+                isValidUrl(value) ?
+                    <Button
+                        data-cy="manage-themes"
+                        variant="secondary"
+                        isSmall
+                        onClick={() => fetchFile(value).then(onCodeFetched)}>
+                        {__('Fetch Code', 'code-block-pro')}
+                    </Button> :
+                    null
+            }
         </BaseControl>
     );
 };

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -34,7 +34,7 @@ export const GitHubRepositoryControl = ({value, onChange, onCodeFetched}: GitHub
                     data-cy="github-repository-link"
                     label={__('Github Repository Link', 'code-block-pro')}
                     help={__(
-                        'The link to your file. Supports raw.githubusercontent.com links.',
+                        'The link to your file. Supports github.com and raw.githubusercontent.com links.',
                         'code-block-pro',
                     )}
                     value={value}
@@ -60,7 +60,7 @@ function isValidUrl(str: string) {
     try {
         const url = new URL(str);
 
-        if (url.host !== 'raw.githubusercontent.com') {
+        if (url.host !== 'raw.githubusercontent.com' && url.host !== 'github.com') {
             return false;
         }
     } catch (e) {

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -40,7 +40,7 @@ export const GitHubRepositoryControl = ({value, onChange, onCodeFetched}: GitHub
                     data-cy="github-repository-link"
                     label={__('Github Repository Link', 'code-block-pro')}
                     help={__(
-                        'The link to your file. Supports github.com and raw.githubusercontent.com links.',
+                        'The link to your file. Supports github.com links, gists, and raw content links.',
                         'code-block-pro',
                     )}
                     value={value}

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -107,11 +107,10 @@ function getLineNumberFromToken(token: string) {
     return parseInt(lineNumber);
 }
 
-
 async function fetchFile(url: string) {
     const response = await apiFetch({
         path: 'code-block-pro/v1/code',
-        method: 'POST',
+        method: 'GET',
         data: {url},
     });
 

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -1,17 +1,22 @@
 import {BaseControl, TextControl,} from '@wordpress/components';
 import {useEffect, useRef} from '@wordpress/element';
 import {__} from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 
 interface GitHubRepositoryControlProps {
     value: string;
     onChange: (value: string) => void;
 }
 
-export const GitHubRepositoryControl = ({value, onChange}: GitHubRepositoryControlProps) => {
+export const GitHubRepositoryControl = ({value, onChange, onCodeFetched}: GitHubRepositoryControlProps) => {
     const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         if (isValidUrl(value)) {
+            fetchFile(value).then((code) => {
+                onCodeFetched(code);
+            });
+
             inputRef.current
                 ?.querySelector('input')
                 ?.classList.remove('cbp-input-error');
@@ -54,4 +59,14 @@ function isValidUrl(str: string) {
     }
 
     return true;
+}
+
+async function fetchFile(url: string) {
+    const response = await apiFetch({
+        path: 'code-block-pro/v1/code',
+        method: 'POST',
+        data: {url},
+    });
+
+    return response.code;
 }

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -51,7 +51,7 @@ export const GitHubRepositoryControl = ({
                 help={
                     error ?
                         <p style={{ color: 'red'}}>{__(error, 'code-block-pro')}</p> :
-                        <p>{__('The link to your file. Supports GitHub links and gists.', 'code-block-pro')}</p>
+                        <p>{__('Supports GitHub file links and Gists.', 'code-block-pro')}</p>
                 }
                 value={remoteCodeRepositoryUrl}
                 onChange={(value) => setAttributes({ remoteCodeRepositoryUrl: value })}
@@ -62,7 +62,7 @@ export const GitHubRepositoryControl = ({
                     variant="secondary"
                     isSmall
                     onClick={() => mutate(remoteCodeRepositoryUrl)}>
-                    {__('Fetch Code', 'code-block-pro')}
+                    {__('Save', 'code-block-pro')}
                 </Button>
             )}
         </BaseControl>

--- a/src/editor/controls/GitHubRepositoryControl.tsx
+++ b/src/editor/controls/GitHubRepositoryControl.tsx
@@ -38,9 +38,9 @@ export const GitHubRepositoryControl = ({
 
     // Sets the code to the remotely fetched code
     useEffect(() => {
-        if (loading || error) return;
+        if (loading || error || !code) return;
 
-        setAttributes({ code: code });
+        setAttributes({ code });
     }, [code, loading, error]);
 
     return (

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -398,7 +398,7 @@ export const SidebarControls = ({
             </PanelBody>
             <PanelBody
                 title={__('GitHub', 'code-block-pro')}
-                initialOpen={bringAttention === 'language-select'}>
+                initialOpen={false}>
                 <div className="code-block-pro-editor">
                     <GitHubRepositoryControl
                         value={attributes.remoteCodeRepositoryUrl}

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -404,7 +404,6 @@ export const SidebarControls = ({
                         value={attributes.remoteCodeRepositoryUrl}
                         onChange={(url) => {
                             setAttributes({ remoteCodeRepositoryUrl: url });
-                            updateThemeHistory({ remoteCodeRepositoryUrl: url });
                         }}
                         onCodeFetched={({ code, lineNumbers }) => {
                             setAttributes({

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -378,7 +378,6 @@ export const SidebarControls = ({
                         onChange={(size) => {
                             const tabSize = size ? Number(size) : undefined;
                             setAttributes({ tabSize });
-                            updateThemeHistory({ tabSize });
                         }}
                     />
                     <CheckboxControl

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -402,6 +402,9 @@ export const SidebarControls = ({
                                 setAttributes({ url });
                                 updateThemeHistory({ url });
                             }}
+                            onCodeFetched={(text: string) => {
+                                console.log(text);
+                            }}
                         />
                     </BaseControl>
                 </div>

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -400,22 +400,20 @@ export const SidebarControls = ({
                 title={__('GitHub', 'code-block-pro')}
                 initialOpen={bringAttention === 'language-select'}>
                 <div className="code-block-pro-editor">
-                    <BaseControl id="code-block-pro-language">
-                        <GitHubRepositoryControl
-                            value={attributes.remoteCodeRepositoryUrl}
-                            onChange={(url) => {
-                                setAttributes({ remoteCodeRepositoryUrl: url });
-                                updateThemeHistory({ remoteCodeRepositoryUrl: url });
-                            }}
-                            onCodeFetched={({ code, lineNumbers }) => {
-                                setAttributes({
-                                    code,
-                                    enableHighlighting: Boolean(lineNumbers),
-                                    lineHighlights: Boolean(lineNumbers) ? `[${lineNumbers.startLine},${lineNumbers.endLine}]` : '',
-                                });
-                            }}
-                        />
-                    </BaseControl>
+                    <GitHubRepositoryControl
+                        value={attributes.remoteCodeRepositoryUrl}
+                        onChange={(url) => {
+                            setAttributes({ remoteCodeRepositoryUrl: url });
+                            updateThemeHistory({ remoteCodeRepositoryUrl: url });
+                        }}
+                        onCodeFetched={({ code, lineNumbers }) => {
+                            setAttributes({
+                                code,
+                                enableHighlighting: Boolean(lineNumbers),
+                                lineHighlights: Boolean(lineNumbers) ? `[${lineNumbers.startLine},${lineNumbers.endLine}]` : '',
+                            });
+                        }}
+                    />
                 </div>
             </PanelBody>
         </InspectorControls>

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -402,10 +402,10 @@ export const SidebarControls = ({
                 <div className="code-block-pro-editor">
                     <BaseControl id="code-block-pro-language">
                         <GitHubRepositoryControl
-                            value={attributes.url}
+                            value={attributes.remoteCodeRepositoryUrl}
                             onChange={(url) => {
-                                setAttributes({ url });
-                                updateThemeHistory({ url });
+                                setAttributes({ remoteCodeRepositoryUrl: url });
+                                updateThemeHistory({ remoteCodeRepositoryUrl: url });
                             }}
                             onCodeFetched={({ code, lineNumbers }) => {
                                 setAttributes({

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -396,7 +396,7 @@ export const SidebarControls = ({
                 </BaseControl>
             </PanelBody>
             <PanelBody
-                title={__('GitHub', 'code-block-pro')}
+                title={__('Remote Code Sync', 'code-block-pro')}
                 initialOpen={false}>
                 <div className="code-block-pro-editor">
                     <GitHubRepositoryControl

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -390,6 +390,30 @@ export const SidebarControls = ({
                     />
                 </BaseControl>
             </PanelBody>
+            <PanelBody
+                title={__('GitHub', 'code-block-pro')}
+                initialOpen={bringAttention === 'language-select'}>
+                <div className="code-block-pro-editor">
+                    <BaseControl id="code-block-pro-language">
+                        <TextControl
+                            spellCheck={false}
+                            autoComplete="off"
+                            type="text"
+                            data-cy="editor-tab-size"
+                            label={__('Github Repository Link', 'code-block-pro')}
+                            help={__(
+                                'The GitHub link to your file. Supports both github.com and githubusercontent.com links.',
+                                'code-block-pro',
+                            )}
+                            value={attributes.url}
+                            onChange={(url) => {
+                                setAttributes({ url });
+                                updateThemeHistory({ url });
+                            }}
+                        />
+                    </BaseControl>
+                </div>
+            </PanelBody>
         </InspectorControls>
     );
 };

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -401,17 +401,8 @@ export const SidebarControls = ({
                 initialOpen={false}>
                 <div className="code-block-pro-editor">
                     <GitHubRepositoryControl
-                        value={attributes.remoteCodeRepositoryUrl}
-                        onChange={(url) => {
-                            setAttributes({ remoteCodeRepositoryUrl: url });
-                        }}
-                        onCodeFetched={({ code, lineNumbers }) => {
-                            setAttributes({
-                                code,
-                                enableHighlighting: Boolean(lineNumbers),
-                                lineHighlights: Boolean(lineNumbers) ? `[${lineNumbers.startLine},${lineNumbers.endLine}]` : '',
-                            });
-                        }}
+                        remoteCodeRepositoryUrl={attributes.remoteCodeRepositoryUrl}
+                        setAttributes={setAttributes}
                     />
                 </div>
             </PanelBody>

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -396,7 +396,7 @@ export const SidebarControls = ({
                 </BaseControl>
             </PanelBody>
             <PanelBody
-                title={__('Remote Code Sync', 'code-block-pro')}
+                title={__('Sync', 'code-block-pro')}
                 initialOpen={false}>
                 <div className="code-block-pro-editor">
                     <GitHubRepositoryControl

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -402,8 +402,8 @@ export const SidebarControls = ({
                                 setAttributes({ url });
                                 updateThemeHistory({ url });
                             }}
-                            onCodeFetched={(text: string) => {
-                                console.log(text);
+                            onCodeFetched={(code) => {
+                                setAttributes({ code });
                             }}
                         />
                     </BaseControl>

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -402,8 +402,12 @@ export const SidebarControls = ({
                                 setAttributes({ url });
                                 updateThemeHistory({ url });
                             }}
-                            onCodeFetched={(code) => {
-                                setAttributes({ code });
+                            onCodeFetched={({ code, lineNumbers }) => {
+                                setAttributes({
+                                    code,
+                                    enableHighlighting: Boolean(lineNumbers),
+                                    lineHighlights: Boolean(lineNumbers) ? `[${lineNumbers.startLine},${lineNumbers.endLine}]` : '',
+                                });
                             }}
                         />
                     </BaseControl>

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -32,6 +32,7 @@ import { ThemesPanel } from '../components/ThemesPanel';
 import { MissingPermissionsTip } from '../components/misc/MissingPermissions';
 import { BlurControl } from './BlurControl';
 import { HighlightingControl } from './HighlightingControl';
+import {GitHubRepositoryControl} from "./GitHubRepositoryControl";
 
 export const SidebarControls = ({
     attributes,
@@ -395,16 +396,7 @@ export const SidebarControls = ({
                 initialOpen={bringAttention === 'language-select'}>
                 <div className="code-block-pro-editor">
                     <BaseControl id="code-block-pro-language">
-                        <TextControl
-                            spellCheck={false}
-                            autoComplete="off"
-                            type="text"
-                            data-cy="editor-tab-size"
-                            label={__('Github Repository Link', 'code-block-pro')}
-                            help={__(
-                                'The GitHub link to your file. Supports both github.com and githubusercontent.com links.',
-                                'code-block-pro',
-                            )}
+                        <GitHubRepositoryControl
                             value={attributes.url}
                             onChange={(url) => {
                                 setAttributes({ url });

--- a/src/hooks/useRemoteCodeFetching.ts
+++ b/src/hooks/useRemoteCodeFetching.ts
@@ -1,0 +1,18 @@
+import apiFetch from '@wordpress/api-fetch';
+import useSWR, { mutate } from "swr";
+import { isValidUrl } from "../util/urls";
+
+const fetcher = async (url: string) => {
+    const response = await apiFetch({
+        path: `code-block-pro/v1/code?url=${ encodeURIComponent(url) }`,
+        method: 'GET',
+    });
+
+    return response.code;
+};
+
+export function useRemoteCodeFetching(url: string) {
+    const { data, loading, error } = useSWR(isValidUrl(url) ? url : null, fetcher);
+
+    return { data, loading, error, mutate };
+}

--- a/src/hooks/useRemoteCodeFetching.ts
+++ b/src/hooks/useRemoteCodeFetching.ts
@@ -4,7 +4,7 @@ import { isValidUrl } from "../util/urls";
 
 const fetcher = async (url: string) => {
     const response = await apiFetch({
-        path: `code-block-pro/v1/code?url=${ encodeURIComponent(url) }`,
+        path: `code-block-pro/v1/code?url=${encodeURIComponent(url)}`,
         method: 'GET',
     });
 
@@ -14,5 +14,13 @@ const fetcher = async (url: string) => {
 export function useRemoteCodeFetching(url: string) {
     const { data, isLoading, error } = useSWR(isValidUrl(url) ? url : null, fetcher);
 
-    return { code: data, loading: isLoading, error, mutate };
+    let errorMessage = null;
+    if (!isValidUrl(url)) {
+        errorMessage = 'Please enter a valid URL';
+    } else if (error) {
+        errorMessage = error.message;
+    }
+
+
+    return { code: data, loading: isLoading, error: errorMessage, mutate };
 }

--- a/src/hooks/useRemoteCodeFetching.ts
+++ b/src/hooks/useRemoteCodeFetching.ts
@@ -14,5 +14,5 @@ const fetcher = async (url: string) => {
 export function useRemoteCodeFetching(url: string) {
     const { data, isLoading, error } = useSWR(isValidUrl(url) ? url : null, fetcher);
 
-    return { code: data, isLoading, error, mutate };
+    return { code: data, loading: isLoading, error, mutate };
 }

--- a/src/hooks/useRemoteCodeFetching.ts
+++ b/src/hooks/useRemoteCodeFetching.ts
@@ -12,7 +12,7 @@ const fetcher = async (url: string) => {
 };
 
 export function useRemoteCodeFetching(url: string) {
-    const { data, loading, error } = useSWR(isValidUrl(url) ? url : null, fetcher);
+    const { data, isLoading, error } = useSWR(isValidUrl(url) ? url : null, fetcher);
 
-    return { data, loading, error, mutate };
+    return { code: data, isLoading, error, mutate };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,7 +58,7 @@ registerBlockType<Attributes>(blockConfig.name, {
         useDecodeURI: { type: 'boolean', default: false },
         tabSize: { type: 'number', default: 2 },
         useTabs: { type: 'boolean' },
-        url: { type: 'string' },
+        remoteCodeRepositoryUrl: { type: 'string' },
     },
     // Need to add these here to avoid TS type errors
     supports: {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,6 +68,7 @@ registerBlockType<Attributes>(blockConfig.name, {
         useDecodeURI: { type: 'boolean', default: false },
         tabSize: { type: 'number', default: 2 },
         useTabs: { type: 'boolean' },
+        url: { type: 'string' },
     },
     // Need to add these here to avoid TS type errors
     supports: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export type Attributes = {
     useDecodeURI: boolean;
     tabSize: number;
     useTabs: boolean;
-    url: string;
+    remoteCodeRepositoryUrl: string;
 };
 export interface AttributesPropsAndSetter {
     attributes: Attributes;

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export type Attributes = {
     useDecodeURI: boolean;
     tabSize: number;
     useTabs: boolean;
+    url: string;
 };
 export interface AttributesPropsAndSetter {
     attributes: Attributes;

--- a/src/util/urls.ts
+++ b/src/util/urls.ts
@@ -1,0 +1,40 @@
+export function isValidUrl(str: string) {
+    try {
+        const url = new URL(str);
+
+        return url.host === 'raw.githubusercontent.com' ||
+            url.host === 'gist.githubusercontent.com' ||
+            url.host === 'github.com';
+    } catch (e) {
+        return false;
+    }
+}
+
+export function extractLineNumbers(url) {
+    const hashIndex = url.indexOf("#L");
+    if (hashIndex === -1) {
+        return null;
+    }
+
+    const strAfterHash = url.substring(hashIndex + 1);
+    const strSplitByDash = strAfterHash.split('-');
+    const lineNumbers = strSplitByDash.map(getLineNumberFromToken);
+
+    const isFirstNumberValid = lineNumbers[0] > 0;
+    const isSecondNumberValid = lineNumbers[1] > 0;
+    if (!isFirstNumberValid) {
+        return null;
+    }
+
+    return {
+        startLine: lineNumbers[0],
+        endLine: isSecondNumberValid ? lineNumbers[1] : lineNumbers[0],
+    };
+}
+
+function getLineNumberFromToken(token: string) {
+    const splitByColumn = token.split('C');
+    const lineNumber = splitByColumn[0].substring(1);
+
+    return parseInt(lineNumber);
+}


### PR DESCRIPTION
This PR closes #246 

Notes:
- Created a new route under /code
- Added a new control component: `GitHubRepositoryControl`
- The only allowed hosts are: `raw.githubusercontent.com`, `gist.githubusercontent.com`, and `github.com`
- Code is only fetched if it passes frontend validation
- Applies highlights based off of URL given, so links ending with #L12 or something will highlight line 12. Also supports ranges like #L1-L20

This might be overkill, but one immediate extension I could see being made to this is allowing code from sources like GitLab or something, but that's a problem for the future.

I did intend to implement some cypress tests, but I for the life of me could not figure out how to get an environment set up. I can figure it out, but I thought it would be nice to get some feedback while I figure it out.