### PR TITLE
Add pluggable sidebar slots

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -15,6 +15,8 @@
  * @package           kevinbatdorf
  */
 
+defined('ABSPATH') or die;
+
 add_action('init', function () {
     register_block_type(__DIR__ . '/build');
     wp_set_script_translations('kevinbatdorf/code-block-pro', 'code-block-pro');

--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Feature: Add pluggable sidebar slots to allow others to add functionality
+
 = 1.24.1 - 2023-10-11 =
 - Tweak: Line numbers width is now calculated based on the longest line number * font width
 - Compatibility: Checks whether the user has permission via the browser instead of passing it in from the server (other plugins were intercepting this check)

--- a/src/editor/components/SlotFactory.tsx
+++ b/src/editor/components/SlotFactory.tsx
@@ -1,0 +1,29 @@
+import { createSlotFill } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
+import { AttributesPropsAndSetter } from '../../types';
+import { decode, encode } from '../../util/code';
+import { languages } from '../../util/languages';
+
+export const SlotFactory = ({
+    name,
+    attributes,
+    setAttributes,
+}: AttributesPropsAndSetter & { name: string }) => {
+    const { Slot } = useMemo(() => {
+        return createSlotFill(name);
+    }, [name]);
+    return (
+        <Slot
+            fillProps={{
+                attributes,
+                setAttributes,
+                languages,
+                getCode: () => decode(attributes.code, attributes),
+                setCode: (code: string) =>
+                    setAttributes({
+                        code: encode(code, attributes),
+                    }),
+            }}
+        />
+    );
+};

--- a/src/editor/controls/Sidebar.tsx
+++ b/src/editor/controls/Sidebar.tsx
@@ -29,6 +29,7 @@ import {
 import { FooterSelect } from '../components/FooterSelect';
 import { HeaderSelect } from '../components/HeaderSelect';
 import { HeightPanel } from '../components/HeightPanel';
+import { SlotFactory } from '../components/SlotFactory';
 import { ThemesPanel } from '../components/ThemesPanel';
 import { MissingPermissionsTip } from '../components/misc/MissingPermissions';
 import { BlurControl } from './BlurControl';
@@ -79,6 +80,11 @@ export const SidebarControls = ({
 
     return (
         <InspectorControls>
+            <SlotFactory
+                name="CodeBlockPro.Sidebar.Start"
+                attributes={attributes}
+                setAttributes={setAttributes}
+            />
             <PanelBody
                 title={__('Language', 'code-block-pro')}
                 initialOpen={bringAttention === 'language-select'}>
@@ -128,49 +134,11 @@ export const SidebarControls = ({
                     </BaseControl>
                 </div>
             </PanelBody>
-            <PanelBody
-                title={__('Line Settings', 'code-block-pro')}
-                initialOpen={false}>
-                <div className="code-block-pro-editor">
-                    <BaseControl id="code-block-pro-show-line-numbers">
-                        <CheckboxControl
-                            data-cy="show-line-numbers"
-                            label={__('Line numbers', 'code-block-pro')}
-                            help={__(
-                                'Enable line numbers and set a starting number.',
-                                'code-block-pro',
-                            )}
-                            checked={attributes.lineNumbers}
-                            onChange={(lineNumbers) => {
-                                setAttributes({ lineNumbers });
-                                updateThemeHistory({ lineNumbers });
-                            }}
-                        />
-                        {attributes.lineNumbers && (
-                            <BaseControl id="code-block-pro-line-number-start">
-                                <TextControl
-                                    id="code-block-pro-line-number-start"
-                                    spellCheck={false}
-                                    autoComplete="off"
-                                    label={__('Start from', 'code-block-pro')}
-                                    onChange={(startingLineNumber) => {
-                                        setAttributes({ startingLineNumber });
-                                    }}
-                                    value={attributes.startingLineNumber}
-                                />
-                            </BaseControl>
-                        )}
-                    </BaseControl>
-                    <HighlightingControl
-                        attributes={attributes}
-                        setAttributes={setAttributes}
-                    />
-                    <BlurControl
-                        attributes={attributes}
-                        setAttributes={setAttributes}
-                    />
-                </div>
-            </PanelBody>
+            <ThemesPanel
+                bringAttentionToThemes={bringAttention === 'theme-select'}
+                attributes={attributes}
+                setAttributes={setAttributes}
+            />
             <PanelBody
                 title={__('Header Type', 'code-block-pro')}
                 initialOpen={false}>
@@ -256,8 +224,51 @@ export const SidebarControls = ({
                     }}
                 />
             </PanelBody>
-            <ThemesPanel
-                bringAttentionToThemes={bringAttention === 'theme-select'}
+            <PanelBody
+                title={__('Line Settings', 'code-block-pro')}
+                initialOpen={false}>
+                <div className="code-block-pro-editor">
+                    <BaseControl id="code-block-pro-show-line-numbers">
+                        <CheckboxControl
+                            data-cy="show-line-numbers"
+                            label={__('Line numbers', 'code-block-pro')}
+                            help={__(
+                                'Enable line numbers and set a starting number.',
+                                'code-block-pro',
+                            )}
+                            checked={attributes.lineNumbers}
+                            onChange={(lineNumbers) => {
+                                setAttributes({ lineNumbers });
+                                updateThemeHistory({ lineNumbers });
+                            }}
+                        />
+                        {attributes.lineNumbers && (
+                            <BaseControl id="code-block-pro-line-number-start">
+                                <TextControl
+                                    id="code-block-pro-line-number-start"
+                                    spellCheck={false}
+                                    autoComplete="off"
+                                    label={__('Start from', 'code-block-pro')}
+                                    onChange={(startingLineNumber) => {
+                                        setAttributes({ startingLineNumber });
+                                    }}
+                                    value={attributes.startingLineNumber}
+                                />
+                            </BaseControl>
+                        )}
+                    </BaseControl>
+                    <HighlightingControl
+                        attributes={attributes}
+                        setAttributes={setAttributes}
+                    />
+                    <BlurControl
+                        attributes={attributes}
+                        setAttributes={setAttributes}
+                    />
+                </div>
+            </PanelBody>
+            <SlotFactory
+                name="CodeBlockPro.Sidebar.Middle"
                 attributes={attributes}
                 setAttributes={setAttributes}
             />
@@ -395,6 +406,11 @@ export const SidebarControls = ({
                     />
                 </BaseControl>
             </PanelBody>
+            <SlotFactory
+                name="CodeBlockPro.Sidebar.End"
+                attributes={attributes}
+                setAttributes={setAttributes}
+            />
         </InspectorControls>
     );
 };

--- a/src/util/code.ts
+++ b/src/util/code.ts
@@ -1,0 +1,27 @@
+import { escapeHTML } from '@wordpress/escape-html';
+import { decodeEntities } from '@wordpress/html-entities';
+import { Attributes } from '../types';
+
+export const encode = (code: string, { useDecodeURI }: Partial<Attributes>) => {
+    if (useDecodeURI) {
+        try {
+            // Here for bw compatability
+            return encodeURIComponent(code);
+        } catch (e) {
+            return code;
+        }
+    }
+    return escapeHTML(code);
+};
+
+export const decode = (code: string, { useDecodeURI }: Partial<Attributes>) => {
+    if (useDecodeURI) {
+        try {
+            // Here for bw compatability
+            return decodeURIComponent(code);
+        } catch (e) {
+            return code;
+        }
+    }
+    return decodeEntities(code);
+};


### PR DESCRIPTION
This adds three sections to the sidebar (just to give a choice for placement) and exposes functionality for anyone to write a plugin.

If you want more functionality exposed, open an issue.

Related conversation: https://github.com/KevinBatdorf/code-block-pro/pull/252#issuecomment-1773092633

Example code for writing a plugin (comment there if you need clarification): https://gist.github.com/KevinBatdorf/de687d5e620dfe2af7645b35b917cd87

![CleanShot 2023-10-21 at 21 25 21](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/8e139a80-b8e7-481b-9ee5-81e91466b23a)
