### PR TITLE
Allow copy override and callback

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Feature: Allow for overriding copy button text and invoke a callback
 - Feature: Added two new programming fonts, Cozette and Deja Vu
 - Feature: Add pluggable sidebar slots to allow others to add functionality
 - Tweak: Renamed Themes to Theme and moved it to the top

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -21,13 +21,17 @@ const handleCopyButton = () => {
             const code = b?.dataset?.encoded
                 ? decodeURIComponent(decodeURIComponent(b?.dataset?.code))
                 : b?.dataset?.code;
-            copy(code ?? '', {
+            const content = window.cbpCopyOverride?.(code, button) ?? code;
+            copy(content ?? '', {
                 format: 'text/plain',
+                onCopy: (code) => {
+                    window.cbpCopyCallback?.(code, button);
+                    b.classList.add('cbp-copying');
+                    setTimeout(() => {
+                        b.classList.remove('cbp-copying');
+                    }, 2_000);
+                },
             });
-            b.classList.add('cbp-copying');
-            setTimeout(() => {
-                b.classList.remove('cbp-copying');
-            }, 2_000);
         };
         ['click', 'keydown'].forEach((evt) =>
             button.addEventListener(evt, handler),


### PR DESCRIPTION
This lets you override the text about to be copied, and also lets you fire a callback after the copy takes place (in case you wanted a custom notification)

```js
window.cbpCopyOverride = (code, button) => {
    console.log('copied!', button, code)
    return `${code}\ntest test test`;
};
window.cbpCopyCallback = (code, button) => {
  console.log('callback', button, code)
}
```