### PR TITLE
Prevent mobile font adjustments

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Fix: Added a css dec to stop long text font upsizing on some mobile devices
+
 = 1.25.0 - 2023-11-13 =
 - Feature: Allow for overriding copy button text and invoke a callback
 - Feature: Added new programming fonts, Monaspace (5), Geist, Cozette and Deja Vu

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -3,6 +3,7 @@
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
         monospace; /* no !important */
     direction: ltr;
+    -webkit-text-size-adjust: 100%;
     @apply relative box-border;
     * {
         @apply box-border;


### PR DESCRIPTION
This prevents some mobile browsers like Safari from increasing the font size on some strings

Closes https://github.com/KevinBatdorf/code-block-pro/issues/273