### PR TITLE
Add copy button with text

### DIFF
--- a/cypress/e2e/buttons.cy.js
+++ b/cypress/e2e/buttons.cy.js
@@ -97,7 +97,7 @@ context('Copy button', () => {
         });
     });
 
-    it.only('Lets the text button change text', () => {
+    it('Lets the text button change text', () => {
         cy.openSideBarPanel('Buttons');
 
         cy.get('[data-cy="copy-button"]').should('exist').should('be.checked');

--- a/cypress/e2e/buttons.cy.js
+++ b/cypress/e2e/buttons.cy.js
@@ -36,8 +36,8 @@ context('Copy button', () => {
         cy.get('[data-cy="copy-button"]').should('exist').should('be.checked');
         cy.getPostContent('.wp-block[class$="code-block-pro"]')
             .invoke('html')
-            .should('contain', 'M9 5H7a2 2 0 00-2 2v12a2') // Clipboard.js
-            .should('not.contain', 'M16.5 8.25V6a2.25 2.25'); // TwoSquares.js
+            .should('contain', 'M9 5H7a2 2 0 00-2 2v12a2') // Clipboard.tsx
+            .should('not.contain', 'M16.5 8.25V6a2.25 2.25'); // TwoSquares.tsx
 
         cy.get('#code-block-pro-copy-button-heroicons')
             .should('exist')
@@ -48,8 +48,8 @@ context('Copy button', () => {
 
         cy.getPostContent('.wp-block[class$="code-block-pro"]')
             .invoke('html')
-            .should('contain', 'M16.5 8.25V6a2.25 2.25') // TwoSquares.js
-            .should('not.contain', 'M9 5H7a2 2 0 00-2 2v12a2'); // Clipboard.js
+            .should('contain', 'M16.5 8.25V6a2.25 2.25') // TwoSquares.tsx
+            .should('not.contain', 'M9 5H7a2 2 0 00-2 2v12a2'); // Clipboard.tsx
     });
 
     it('Hides buttons when unchecked', () => {
@@ -95,6 +95,63 @@ context('Copy button', () => {
                 expect(clipText).to.equal(text);
             });
         });
+    });
+
+    it.only('Lets the text button change text', () => {
+        cy.openSideBarPanel('Buttons');
+
+        cy.get('[data-cy="copy-button"]').should('exist').should('be.checked');
+        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+            .invoke('html')
+            .should('contain', 'M9 5H7a2 2 0 00-2 2v12a2') // Clipboard.tsx
+            .should('not.contain', '<span class="cbp-btn-text">Copy'); // TextSimple.tsx
+        cy.get('#code-block-pro-copy-button-heroicons')
+            .should('exist')
+            .should('have.attr', 'aria-current', 'true');
+
+        // Can change to the text button
+        cy.get('#code-block-pro-copy-button-textSimple').should('exist');
+        cy.get('#code-block-pro-copy-button-textSimple').click();
+
+        // Button changed - expected default text is shown
+        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+            .invoke('html')
+            .should('contain', '<span class="cbp-btn-text">Copy') // TextSimple.tsx
+            .should('not.contain', 'M9 5H7a2 2 0 00-2 2v12a2'); // Clipboard.tsx
+
+        // Clear the text then test that it can be changed
+        cy.get('#code-block-pro-copy-button-text')
+            .should('exist')
+            .should('have.value', 'Copy')
+            .clear();
+        cy.get('#code-block-pro-copy-button-text').type('foo-bar-baz-lets-go');
+        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+            .invoke('html')
+            .should('contain', '<span class="cbp-btn-text">foo-bar-baz-lets-go')
+            .should('not.contain', '<span class="cbp-btn-text">Copy');
+
+        // Do the same for the Copied! text
+        cy.get('#code-block-pro-copy-button-text-copied')
+            .should('exist')
+            .should('have.value', 'Copied!')
+            .clear();
+        cy.get('#code-block-pro-copy-button-text-copied').type('it worked!');
+
+        cy.addCode('hi friends');
+        cy.previewCurrentPage();
+
+        // Check the text shows on the front end
+        cy.get('.wp-block-kevinbatdorf-code-block-pro')
+            .invoke('html')
+            .should(
+                'contain',
+                '<span class="cbp-btn-text">foo-bar-baz-lets-go',
+            );
+        // Click the copy button and the text should change
+        cy.get('.code-block-pro-copy-button').should('exist').realClick();
+        cy.get('.wp-block-kevinbatdorf-code-block-pro')
+            .invoke('html')
+            .should('contain', '<span class="cbp-btn-text">it worked!');
     });
 
     // Doesn't seem to work 🤷

--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Feature: Added a copy button that allows for text inputs
 - Fix: Added a css dec to stop long text font upsizing on some mobile devices
 
 = 1.25.0 - 2023-11-13 =

--- a/src/block.json
+++ b/src/block.json
@@ -45,6 +45,9 @@
         "renderType": { "type": "string", "default": "code" },
         "label": { "type": "string", "default": "" },
         "copyButton": { "type": "boolean" },
+        "copyButtonType": { "type": "string" },
+        "copyButtonString": { "type": "string" },
+        "copyButtonStringCopied": { "type": "string" },
         "tabSize": { "type": "number" },
         "useTabs": { "type": "boolean" }
     },

--- a/src/editor/components/FooterSelect.tsx
+++ b/src/editor/components/FooterSelect.tsx
@@ -34,7 +34,7 @@ export const FooterSelect = ({ attributes, onClick }: FooterSelectProps) => {
                         ['simpleStringEnd', 'simpleStringStart'].includes(slug)
                             ? // Settings refers to the panel that can be expanded
                               __(
-                                  'Update extra settings above',
+                                  'Set the text at the top of this panel.',
                                   'code-block-pro',
                               )
                             : undefined

--- a/src/editor/components/HeaderSelect.tsx
+++ b/src/editor/components/HeaderSelect.tsx
@@ -50,7 +50,7 @@ export const HeaderSelect = ({ attributes, onClick }: HeaderSelectProps) => {
                         )
                             ? // Settings refers to the panel that can be expanded
                               __(
-                                  'Update extra settings above',
+                                  'Set the text at the top of this panel.',
                                   'code-block-pro',
                               )
                             : undefined

--- a/src/editor/components/buttons/copy/CopyButton.tsx
+++ b/src/editor/components/buttons/copy/CopyButton.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import stripAnsi from 'strip-ansi';
 import { Attributes } from '../../../../types';
 import { Clipboard } from './Clipboard';
+import { TextSimple } from './TextSimple';
 import { TwoSquares } from './TwoSquares';
 
 export const copyButtonTypes = {
@@ -14,31 +15,55 @@ export const copyButtonTypes = {
         label: __('Two Squares', 'code-block-pro'),
         Component: TwoSquares,
     },
+    textSimple: {
+        label: __('Text Simple', 'code-block-pro'),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Component: (props: any) => <TextSimple {...props} />,
+    },
 };
 
 export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
+    const {
+        copyButtonType,
+        copyButtonString,
+        copyButtonStringCopied,
+        useDecodeURI,
+        code,
+        textColor,
+        bgColor: b,
+        headerType,
+    } = attributes;
+    const hasTextButton = copyButtonType === 'textSimple';
+    const color = hasTextButton ? b : textColor;
+    const bgColor = hasTextButton ? textColor : undefined;
     const { Component } =
-        copyButtonTypes?.[
-            attributes.copyButtonType as keyof typeof copyButtonTypes
-        ] ?? copyButtonTypes.heroicons;
+        copyButtonTypes?.[copyButtonType as keyof typeof copyButtonTypes] ??
+        copyButtonTypes.heroicons;
     return (
         <span
             // Using a span to prevent aggressive button styling from themes
             role="button"
             tabIndex={0}
-            data-encoded={attributes.useDecodeURI ? true : undefined}
+            data-encoded={useDecodeURI ? true : undefined}
             data-code={stripAnsi(
-                attributes.useDecodeURI
-                    ? encodeURIComponent(attributes.code ?? '')
-                    : attributes.code ?? '',
+                useDecodeURI ? encodeURIComponent(code ?? '') : code ?? '',
             )}
             style={{
-                color: attributes?.textColor ?? 'inherit',
+                color: color ?? 'inherit',
                 display: 'none',
+                backgroundColor: bgColor,
             }}
-            aria-label={__('Copy', 'code-block-pro')}
+            aria-label={copyButtonString ?? __('Copy', 'code-block-pro')}
+            data-copied-text={
+                hasTextButton
+                    ? copyButtonStringCopied ?? __('Copied!', 'code-block-pro')
+                    : undefined
+            }
+            data-has-text-button={hasTextButton ? copyButtonType : undefined}
+            data-inside-header-type={hasTextButton ? headerType : undefined}
+            aria-live={hasTextButton ? 'polite' : undefined}
             className="code-block-pro-copy-button">
-            <Component />
+            <Component text={copyButtonString} />
         </span>
     );
 };

--- a/src/editor/components/buttons/copy/TextSimple.tsx
+++ b/src/editor/components/buttons/copy/TextSimple.tsx
@@ -1,0 +1,25 @@
+import { __ } from '@wordpress/i18n';
+import { Icon, textColor } from '@wordpress/icons';
+
+export const TextSimple = ({
+    text,
+    color,
+}: {
+    text?: string;
+    color?: string;
+}) => {
+    if (text === undefined) {
+        return (
+            <Icon
+                icon={textColor}
+                fill={color}
+                className="border border-solid border-gray-900"
+            />
+        );
+    }
+    return (
+        <span className="cbp-btn-text">
+            {text || __('Copy', 'code-block-pro')}
+        </span>
+    );
+};

--- a/src/editor/components/buttons/sidebar/CopyBtnSettings.tsx
+++ b/src/editor/components/buttons/sidebar/CopyBtnSettings.tsx
@@ -1,4 +1,8 @@
-import { BaseControl, CheckboxControl } from '@wordpress/components';
+import {
+    BaseControl,
+    CheckboxControl,
+    TextControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { useThemeStore } from '../../../../state/theme';
@@ -38,9 +42,7 @@ export const CopyBtnSettings = ({
                                     id={`code-block-pro-copy-button-${slug}`}
                                     type="button"
                                     onClick={() => {
-                                        setAttributes({
-                                            copyButtonType: slug,
-                                        });
+                                        setAttributes({ copyButtonType: slug });
                                         updateThemeHistory({
                                             copyButtonType: slug,
                                         });
@@ -57,12 +59,41 @@ export const CopyBtnSettings = ({
                                         {data.label}
                                     </span>
                                     <span className="pointer-events-none w-full">
-                                        <Component />
+                                        <Component color={color} />
                                     </span>
                                 </button>
                             </div>
                         );
                     })}
+                </div>
+            )}
+            {attributes.copyButton && (
+                <div style={{ marginTop: '1rem' }}>
+                    <TextControl
+                        id="code-block-pro-copy-button-text"
+                        autoComplete="off"
+                        label={__('Button label', 'code-block-pro')}
+                        placeholder={__('Copy', 'code-block-pro')}
+                        onChange={(copyButtonString) => {
+                            setAttributes({ copyButtonString });
+                        }}
+                        value={attributes.copyButtonString ?? ''}
+                    />
+                    {attributes.copyButtonType === 'textSimple' && (
+                        <TextControl
+                            id="code-block-pro-copy-button-text-copied"
+                            autoComplete="off"
+                            label={__('Copied Text', 'code-block-pro')}
+                            placeholder={__('Copied!', 'code-block-pro')}
+                            onChange={(copyButtonStringCopied) => {
+                                setAttributes({ copyButtonStringCopied });
+                            }}
+                            value={attributes.copyButtonStringCopied ?? ''}
+                            help={__(
+                                'Text briefly shown after the code is copied',
+                            )}
+                        />
+                    )}
                 </div>
             )}
         </BaseControl>

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -17,7 +17,7 @@ const handleCopyButton = () => {
             // if keydown event, make sure it's enter or space
             if (type === 'keydown' && !['Enter', ' '].includes(key)) return;
             event.preventDefault();
-            const b = target?.closest('span');
+            const b = target?.closest('span[data-code]');
             const code = b?.dataset?.encoded
                 ? decodeURIComponent(decodeURIComponent(b?.dataset?.code))
                 : b?.dataset?.code;
@@ -27,8 +27,15 @@ const handleCopyButton = () => {
                 onCopy: (code) => {
                     window.cbpCopyCallback?.(code, button);
                     b.classList.add('cbp-copying');
+                    // Check if there is a data-text-copied attribute
+                    const hasTextCopied = b.dataset.copiedText;
+                    const innerSpan = b.querySelector('span');
+                    if (hasTextCopied) innerSpan.innerText = hasTextCopied;
                     setTimeout(() => {
                         b.classList.remove('cbp-copying');
+                        if (hasTextCopied) {
+                            innerSpan.innerText = b.getAttribute('aria-label');
+                        }
                     }, 2_000);
                 },
             });

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -163,9 +163,12 @@
 }
 .code-block-pro-copy-button {
     border: 0;
-    background: none;
     padding: 6px;
-    @apply absolute top-0 right-0 left-auto bg-transparent border-none border-0 cursor-pointer opacity-10 focus:opacity-40 transition-opacity duration-200 ease-in-out leading-none z-10;
+    @apply absolute top-0 right-0 left-auto border-none border-0 cursor-pointer opacity-10 focus:opacity-40 transition-opacity duration-200 ease-in-out leading-none z-10;
+}
+.code-block-pro-copy-button:not([data-has-text-button]) {
+    background: none;
+    @apply bg-transparent;
 }
 .wp-block-kevinbatdorf-code-block-pro.padding-disabled
     .code-block-pro-copy-button {
@@ -178,6 +181,37 @@
 .wp-block-kevinbatdorf-code-block-pro .code-block-pro-copy-button:hover {
     @apply opacity-90;
 }
+.wp-block-kevinbatdorf-code-block-pro:hover .code-block-pro-copy-button[data-has-text-button],
+.code-block-pro-copy-button[data-has-text-button] {
+    @apply opacity-100;
+}
+.wp-block-kevinbatdorf-code-block-pro .code-block-pro-copy-button[data-has-text-button]:hover {
+    @apply opacity-80;
+}
+.code-block-pro-copy-button[data-has-text-button] {
+    margin-top: 0.7rem;
+    @apply block rounded-xl mr-3 py-0.5 px-1.5;
+}
+.code-block-pro-copy-button[data-inside-header-type^="headlights"],
+.code-block-pro-copy-button[data-inside-header-type="headlightsMuted"] {
+    margin-top: 0.85rem;
+}
+.code-block-pro-copy-button[data-inside-header-type="headlightsMutedAlt"] {
+    margin-top: 0.65rem;
+}
+.code-block-pro-copy-button[data-inside-header-type="simpleString"] {
+    margin-top: 0.645rem;
+}
+.code-block-pro-copy-button[data-inside-header-type="pillString"] {
+    @apply mt-4;
+}
+.code-block-pro-copy-button[data-inside-header-type="pillString"] .cbp-btn-text {
+    @apply relative top-px;
+}
+.cbp-btn-text {
+    @apply text-xs;
+}
+
 .code-block-pro-copy-button {
     .without-check {
         @apply block;
@@ -187,6 +221,7 @@
     }
 }
 .code-block-pro-copy-button.cbp-copying {
+    @apply opacity-100;
     .without-check {
         @apply hidden;
     }

--- a/src/hooks/useDefaults.ts
+++ b/src/hooks/useDefaults.ts
@@ -14,6 +14,8 @@ export const useDefaults = ({
         lineHeight,
         copyButton,
         copyButtonType,
+        copyButtonString,
+        copyButtonStringCopied,
         headerType,
         footerType,
         clampFonts,
@@ -39,6 +41,8 @@ export const useDefaults = ({
         previousHighlightingHover,
         previousCopyButton,
         previousCopyButtonType,
+        previousCopyButtonString,
+        previousCopyButtonStringCopied,
         previousTabSize,
         previousUseTabs,
         previousSeeMoreType,
@@ -59,6 +63,23 @@ export const useDefaults = ({
         if (copyButtonType) return;
         setAttributes({ copyButtonType: previousCopyButtonType });
     }, [previousCopyButtonType, copyButtonType, setAttributes]);
+
+    useEffect(() => {
+        if (once.current) return;
+        // Checks undefined to avoid invalidating old blocks
+        if (copyButtonString || copyButtonString === undefined) return;
+        setAttributes({ copyButtonString: previousCopyButtonString });
+    }, [previousCopyButtonString, copyButtonString, setAttributes]);
+
+    useEffect(() => {
+        if (once.current) return;
+        // Checks undefined to avoid invalidating old blocks
+        if (copyButtonStringCopied || copyButtonStringCopied === undefined) {
+            return;
+        }
+        const cpyP = previousCopyButtonStringCopied;
+        setAttributes({ copyButtonStringCopied: cpyP });
+    }, [previousCopyButtonStringCopied, copyButtonStringCopied, setAttributes]);
 
     useEffect(() => {
         if (once.current) return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,6 +55,14 @@ registerBlockType<Attributes>(blockConfig.name, {
         label: { type: 'string', default: '' },
         copyButton: { type: 'boolean' },
         copyButtonType: { type: 'string' },
+        copyButtonString: {
+            type: 'string',
+            default: __('Copy', 'code-block-pro'),
+        },
+        copyButtonStringCopied: {
+            type: 'string',
+            default: __('Copied!', 'code-block-pro'),
+        },
         useDecodeURI: { type: 'boolean', default: false },
         tabSize: { type: 'number', default: 2 },
         useTabs: { type: 'boolean' },

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -1,5 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { create } from 'zustand';
 import { createJSONStorage, devtools, persist } from 'zustand/middleware';
 import { Attributes } from '../types';
@@ -17,6 +18,8 @@ type ThemeType = {
     previousHighlightingHover?: boolean;
     previousCopyButton: boolean;
     previousCopyButtonType: string;
+    previousCopyButtonString?: string;
+    previousCopyButtonStringCopied?: string;
     previousTabSize: number;
     previousUseTabs?: boolean;
     // previousEnableMaxHeight?: boolean;
@@ -46,6 +49,8 @@ const defaultSettings = {
     previousHighlightingHover: false,
     previousCopyButton: true,
     previousCopyButtonType: 'heroicons',
+    previousCopyButtonString: __('Copy', 'code-block-pro'),
+    previusCopyButtonStringCopied: __('Copied', 'code-block-pro'),
     previousTabSize: 2,
     previousUseTabs: false,
     // TODO: maybe impliment these with an extra UI to make them optional

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ export type Attributes = {
     label: string;
     copyButton: boolean;
     copyButtonType: string;
+    copyButtonString: string;
+    copyButtonStringCopied: string;
     useDecodeURI: boolean;
     tabSize: number;
     useTabs: boolean;


### PR DESCRIPTION
Adds a copy button with some customizable test

![CleanShot 2024-01-17 at 16 56 42@2x](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/90536f90-03f2-473c-8b3a-7b5b4f03a68e)

The color scheme uses parts of the theme

![CleanShot 2024-01-17 at 16 54 43@2x](https://github.com/KevinBatdorf/code-block-pro/assets/1478421/2991f90b-3aec-4dbb-9b82-073a3a696f19)

I'll probably only keep this design, but if anyone wants instructions on how to override it to match another design just ping me (maybe open an issue or discussion here) and I'll help out