### PR TITLE
Fix bug where plaintext crashes editor

### DIFF
--- a/cypress/e2e/language.cy.js
+++ b/cypress/e2e/language.cy.js
@@ -20,13 +20,15 @@ context('Language checks', () => {
             .invoke('html')
             .should('contain', '<span style="color: #81A1C1">const</span>');
 
-        // Switch to ruby
-        cy.setLanguage('ruby');
-        cy.getPostContent('.wp-block[class$="code-block-pro"]')
+        // TODO - pro only
+        // const lorem = 'Ut laboris anim culpa fugiat sit anim dolor cillum';
+        // cy.addCode(lorem);
+        cy.setLanguage('plaintext');
+        cy.get('.wp-block[class$="code-block-pro"]')
             .invoke('html')
             .should(
                 'contain',
-                '<span style="color: #D8DEE9FF">const foo </span>',
+                'padding: 16px 0px 16px 16px;">const foo = "bar";</textarea>',
             );
     });
 });

--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+= 1.26.1 - 2024-01-31 =
+- Fix: Fixes a bug where the plaintext language would crash the theme render
+
 = 1.26.0 - 2024-01-17 =
 - Feature: Added a copy button that allows for text inputs
 - Feature: Added Roboto Mono font (https://fonts.google.com/specimen/Roboto+Mono)

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -28,7 +28,7 @@ const fetcher = ({ theme, lang, ready }: Params) => {
     )?.[themeFiltered]?.['alias'] as Theme;
 
     return getHighlighter({
-        langs: lang === 'plaintext' ? undefined : [getEditorLanguage(lang)],
+        langs: lang === 'plaintext' ? [] : [getEditorLanguage(lang)],
         theme: themeAlias ?? themeFiltered,
     });
 };


### PR DESCRIPTION
Fixes a bug where plaintext language would error out. I thnk this is because the highlighter on the pro version and this one differ slightly

Closes https://github.com/KevinBatdorf/code-block-pro/issues/283
Related: https://wordpress.org/support/topic/theme-dark-plus-not-found-please-select-a-different-theme