### PR TITLE
Release 1.26.4

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -7,7 +7,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.26.3
+ * Version:           1.26.4
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/readme.txt
+++ b/readme.txt
@@ -313,8 +313,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
-= 1.26.4 - 2024-06-14 =
-- Re-release with updated tag
+= 1.26.4 - 2024-06-18 =
+- Re-release with updated version number in readme. Making this a patch release as I worry some security plugins would otherwise complain.
 
 = 1.26.3 - 2024-06-14 =
 - Fix: Fixes support for ERB template syntax

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82, dcooney
 Tags:              code, syntax, snippet, highlighter, php
 Tested up to:      6.5
-Stable tag:        1.26.2
+Stable tag:        1.26.4
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -312,6 +312,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 5. ANSI support for rendering control sequences
 
 == Changelog ==
+
+= 1.26.4 - 2024-06-14 =
+- Re-release with updated tag
 
 = 1.26.3 - 2024-06-14 =
 - Fix: Fixes support for ERB template syntax


### PR DESCRIPTION
Missed updating the readme on the last tag and I worry there are some security plugins that would make noise if I removed or updated the tag, so I think best to just make a patch release with the version update.