### PR TITLE
Add filter to globally disable font loading

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -22,6 +22,7 @@ add_action('init', function () {
     wp_set_script_translations('kevinbatdorf/code-block-pro', 'code-block-pro');
     wp_add_inline_script('kevinbatdorf-code-block-pro-view-script', 'window.codeBlockPro = ' . wp_json_encode([
         'pluginUrl' => esc_url_raw(plugin_dir_url(__FILE__)),
+        'loadFonts' => apply_filters('code_block_pro_load_fonts', true),
     ]) . ';');
 });
 

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -99,7 +99,7 @@ const handleHighlighter = () => {
 };
 
 const handleFontLoading = () => {
-    if (!window.codeBlockPro?.pluginUrl) return;
+    if (!window.codeBlockPro?.loadFonts || !window.codeBlockPro?.pluginUrl) return;
     const elements = Array.from(
         document.querySelectorAll(
             '[data-code-block-pro-font-family]:not(.cbp-ff-loaded)',


### PR DESCRIPTION
This PR adds a filter that allows users to globally disable custom font loading. 

## Changes
- Adds `code_block_pro_load_fonts` filter with default value of true
- Passes filter value to JavaScript through window.codeBlockPro.loadFonts
- Adds check in handleFontLoading to respect filter setting

## Usage
Users can disable font loading globally by adding this to their theme or plugin:
```php
add_filter('code_block_pro_load_fonts', '__return_false');