### PR TITLE
fix: set toolbar button width auto

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Code Block Pro - Beautiful Syntax Highlighting ===
-Contributors:      kbat82, dcooney, Zhoukaiqiang
+Contributors:      kbat82, dcooney, a169kai
 Tags:              block, code, syntax, highlighter, php
 Tested up to:      6.7
 Stable tag:        1.26.8

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Code Block Pro - Beautiful Syntax Highlighting ===
-Contributors:      kbat82, dcooney
+Contributors:      kbat82, dcooney, Zhoukaiqiang
 Tags:              block, code, syntax, highlighter, php
 Tested up to:      6.7
 Stable tag:        1.26.8

--- a/src/editor/controls/Toolbar.tsx
+++ b/src/editor/controls/Toolbar.tsx
@@ -36,7 +36,7 @@ export const ToolbarControls = ({
                     }
                     onClick={() => setBringAttentionToPanel('language-select')}
                     label={__('Press to open sidebar panel', 'code-block-pro')}
-                    style={{ width: 'unset' }}
+                    style={{ width: 'auto' }}
                 />
             </ToolbarGroup>
             {themes[theme]?.name && (
@@ -48,7 +48,7 @@ export const ToolbarControls = ({
                             'Press to open sidebar panel',
                             'code-block-pro',
                         )}
-                        style={{ width: 'unset' }}>
+                        style={{ width: 'auto' }}>
                         <span className="flex mx-2">
                             <span
                                 style={{

--- a/src/editor/controls/Toolbar.tsx
+++ b/src/editor/controls/Toolbar.tsx
@@ -36,6 +36,7 @@ export const ToolbarControls = ({
                     }
                     onClick={() => setBringAttentionToPanel('language-select')}
                     label={__('Press to open sidebar panel', 'code-block-pro')}
+                    style={{ width: 'unset' }}
                 />
             </ToolbarGroup>
             {themes[theme]?.name && (
@@ -46,7 +47,8 @@ export const ToolbarControls = ({
                         label={__(
                             'Press to open sidebar panel',
                             'code-block-pro',
-                        )}>
+                        )}
+                        style={{ width: 'unset' }}>
                         <span className="flex mx-2">
                             <span
                                 style={{


### PR DESCRIPTION
Hello, I see the button is squeezed in the editor
<img width="530" alt="11" src="https://github.com/user-attachments/assets/48f5eb6b-6a18-4e0b-9fed-e9ea57971905" />
So I make a pr to fix this.