### PR TITLE
Release 1.27.1

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Plugin Name:       Code Block Pro
  * Description:       Code highlighting powered by the VS Code engine
@@ -7,7 +8,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.27.0
+ * Version:           1.27.1
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82, dcooney, a169kai
 Tags:              block, code, syntax, highlighter, php
 Tested up to:      6.8
-Stable tag:        1.27.0
+Stable tag:        1.27.1
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -313,6 +313,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+= 1.27.1 - 2025-05-15 =
 - Now scolls back into view after a max height collapse
 - Disables scroll while the container is expanding
 - Fixes a bug where collapsing doesn't account for headers

--- a/readme.txt
+++ b/readme.txt
@@ -314,7 +314,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 == Changelog ==
 
 = 1.27.1 - 2025-05-15 =
-- Now scolls back into view after a max height collapse
+- Now scrolls back into view after a max height collapse
 - Disables scroll while the container is expanding
 - Fixes a bug where collapsing doesn't account for headers
 


### PR DESCRIPTION
- Now scrolls back into view after a max height collapse
- Disables scroll while the container is expanding
- Fixes a bug where collapsing doesn't account for headers