### PR TITLE
Move copy code to textarea

### DIFF
--- a/cypress/e2e/buttons.cy.js
+++ b/cypress/e2e/buttons.cy.js
@@ -6,7 +6,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {

--- a/cypress/e2e/buttons.cy.js
+++ b/cypress/e2e/buttons.cy.js
@@ -10,7 +10,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert

--- a/cypress/e2e/extra-settings.cy.js
+++ b/cypress/e2e/extra-settings.cy.js
@@ -6,7 +6,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {

--- a/cypress/e2e/extra-settings.cy.js
+++ b/cypress/e2e/extra-settings.cy.js
@@ -10,7 +10,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert

--- a/cypress/e2e/footers.cy.js
+++ b/cypress/e2e/footers.cy.js
@@ -9,7 +9,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert

--- a/cypress/e2e/footers.cy.js
+++ b/cypress/e2e/footers.cy.js
@@ -5,7 +5,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {

--- a/cypress/e2e/headers.cy.js
+++ b/cypress/e2e/headers.cy.js
@@ -9,7 +9,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert

--- a/cypress/e2e/headers.cy.js
+++ b/cypress/e2e/headers.cy.js
@@ -5,7 +5,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {

--- a/cypress/e2e/height.cy.js
+++ b/cypress/e2e/height.cy.js
@@ -5,7 +5,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {
@@ -49,7 +52,10 @@ context('Max Height', () => {
 
         cy.go('back');
 
-        cy.focusBlock('code-block-pro', 'textarea');
+        cy.focusBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        );
         cy.findBlock('code-block-pro', 'textarea').should('have.focus');
         cy.openSideBarPanel('Max Height');
         cy.get('[data-cy="see-more-line"]')
@@ -159,7 +165,10 @@ context('Max Height', () => {
         );
 
         cy.go('back');
-        cy.focusBlock('code-block-pro', 'textarea');
+        cy.focusBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        );
         cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 
         cy.openSideBarPanel('Max Height');
@@ -176,7 +185,10 @@ context('Max Height', () => {
         cy.get('.cbp-see-more-simple-btn').should('not.exist');
 
         cy.go('back');
-        cy.focusBlock('code-block-pro', 'textarea');
+        cy.focusBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        );
         cy.findBlock('code-block-pro', 'textarea').should('have.focus');
         cy.openSideBarPanel('Max Height');
         cy.setHeader('headlights');

--- a/cypress/e2e/height.cy.js
+++ b/cypress/e2e/height.cy.js
@@ -9,7 +9,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert
@@ -56,7 +59,10 @@ context('Max Height', () => {
             'code-block-pro',
             'textarea.npm__react-simple-code-editor__textarea',
         );
-        cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+        cy.findBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        ).should('have.focus');
         cy.openSideBarPanel('Max Height');
         cy.get('[data-cy="see-more-line"]')
             .should('exist')
@@ -169,7 +175,10 @@ context('Max Height', () => {
             'code-block-pro',
             'textarea.npm__react-simple-code-editor__textarea',
         );
-        cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+        cy.findBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        ).should('have.focus');
 
         cy.openSideBarPanel('Max Height');
         cy.get('[data-cy="see-more-line"]')
@@ -189,7 +198,10 @@ context('Max Height', () => {
             'code-block-pro',
             'textarea.npm__react-simple-code-editor__textarea',
         );
-        cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+        cy.findBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        ).should('have.focus');
         cy.openSideBarPanel('Max Height');
         cy.setHeader('headlights');
         cy.setHeightDesign('none');

--- a/cypress/e2e/language.cy.js
+++ b/cypress/e2e/language.cy.js
@@ -9,7 +9,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert

--- a/cypress/e2e/language.cy.js
+++ b/cypress/e2e/language.cy.js
@@ -5,7 +5,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {

--- a/cypress/e2e/lines.cy.js
+++ b/cypress/e2e/lines.cy.js
@@ -10,7 +10,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert
@@ -115,7 +118,10 @@ context('Line highlights', () => {
             'code-block-pro',
             'textarea.npm__react-simple-code-editor__textarea',
         );
-        cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+        cy.findBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        ).should('have.focus');
 
         cy.openSideBarPanel('Line Settings');
         cy.get('[data-cy="enable-highlighting-hover"]').check();

--- a/cypress/e2e/lines.cy.js
+++ b/cypress/e2e/lines.cy.js
@@ -6,7 +6,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {
@@ -108,7 +111,10 @@ context('Line highlights', () => {
         cy.get('.cbp-line-highlighter').should('not.exist');
 
         cy.go('back');
-        cy.focusBlock('code-block-pro', 'textarea');
+        cy.focusBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        );
         cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 
         cy.openSideBarPanel('Line Settings');

--- a/cypress/e2e/misc.cy.js
+++ b/cypress/e2e/misc.cy.js
@@ -6,7 +6,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {

--- a/cypress/e2e/misc.cy.js
+++ b/cypress/e2e/misc.cy.js
@@ -10,7 +10,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert

--- a/cypress/e2e/padding.cy.js
+++ b/cypress/e2e/padding.cy.js
@@ -6,7 +6,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 
     cy.openSideBarPanel('Extra Settings');

--- a/cypress/e2e/padding.cy.js
+++ b/cypress/e2e/padding.cy.js
@@ -10,7 +10,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 
     cy.openSideBarPanel('Extra Settings');
     cy.get('[data-cy="disable-padding"')

--- a/cypress/e2e/rtl.cy.js
+++ b/cypress/e2e/rtl.cy.js
@@ -6,7 +6,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {

--- a/cypress/e2e/rtl.cy.js
+++ b/cypress/e2e/rtl.cy.js
@@ -10,7 +10,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert

--- a/cypress/e2e/styling.cy.js
+++ b/cypress/e2e/styling.cy.js
@@ -5,7 +5,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {
@@ -89,7 +92,10 @@ context('Styling', () => {
 
         cy.go('back');
 
-        cy.focusBlock('code-block-pro', 'textarea');
+        cy.focusBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        );
         cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 
         cy.openSideBarPanel('Styling');

--- a/cypress/e2e/styling.cy.js
+++ b/cypress/e2e/styling.cy.js
@@ -9,7 +9,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert
@@ -96,7 +99,10 @@ context('Styling', () => {
             'code-block-pro',
             'textarea.npm__react-simple-code-editor__textarea',
         );
-        cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+        cy.findBlock(
+            'code-block-pro',
+            'textarea.npm__react-simple-code-editor__textarea',
+        ).should('have.focus');
 
         cy.openSideBarPanel('Styling');
 

--- a/cypress/e2e/themes.cy.js
+++ b/cypress/e2e/themes.cy.js
@@ -8,7 +8,10 @@ beforeEach(() => {
     cy.addBlock('kevinbatdorf/code-block-pro');
     cy.findBlock('code-block-pro').should('exist');
 
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea').should('have.focus');
 });
 afterEach(() => {

--- a/cypress/e2e/themes.cy.js
+++ b/cypress/e2e/themes.cy.js
@@ -12,7 +12,10 @@ beforeEach(() => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea').should('have.focus');
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.focus');
 });
 afterEach(() => {
     cy.saveDraft(); // so we can leave without an alert

--- a/cypress/support/features/code.js
+++ b/cypress/support/features/code.js
@@ -3,13 +3,22 @@ export const addCode = (code, opts) => {
         'code-block-pro',
         'textarea.npm__react-simple-code-editor__textarea',
     );
-    cy.findBlock('code-block-pro', 'textarea')
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    )
         .should('have.focus')
         .type(code, opts);
-    cy.findBlock('code-block-pro', 'textarea').clear();
-    cy.findBlock('code-block-pro', 'textarea').type(code, opts);
-    cy.findBlock('code-block-pro', 'textarea').should(
-        'have.value',
-        opts?.codeOutput ?? code,
-    );
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).clear();
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).type(code, opts);
+    cy.findBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    ).should('have.value', opts?.codeOutput ?? code);
 };

--- a/cypress/support/features/code.js
+++ b/cypress/support/features/code.js
@@ -1,5 +1,8 @@
 export const addCode = (code, opts) => {
-    cy.focusBlock('code-block-pro', 'textarea');
+    cy.focusBlock(
+        'code-block-pro',
+        'textarea.npm__react-simple-code-editor__textarea',
+    );
     cy.findBlock('code-block-pro', 'textarea')
         .should('have.focus')
         .type(code, opts);

--- a/readme.txt
+++ b/readme.txt
@@ -313,6 +313,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Now uses textarea for code copy storing (can revert this under button settings)
+- Removed the WP outline style when clicking the copy button (now only when tab focused)
+
 = 1.27.1 - 2025-05-15 =
 - Now scrolls back into view after a max height collapse
 - Disables scroll while the container is expanding

--- a/src/block.json
+++ b/src/block.json
@@ -50,6 +50,7 @@
         "copyButtonType": { "type": "string" },
         "copyButtonString": { "type": "string" },
         "copyButtonStringCopied": { "type": "string" },
+        "copyButtonUseTextarea": { "type": "boolean", "default": false },
         "tabSize": { "type": "number" },
         "useTabs": { "type": "boolean" }
     },

--- a/src/editor/components/buttons/copy/CopyButton.tsx
+++ b/src/editor/components/buttons/copy/CopyButton.tsx
@@ -43,7 +43,6 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
     const codeToCopy = stripAnsi(
         useDecodeURI ? encodeURIComponent(code ?? '') : (code ?? ''),
     );
-    console.log('codeToCopy', codeToCopy);
     return (
         <span
             // Using a span to prevent aggressive button styling from themes

--- a/src/editor/components/buttons/copy/CopyButton.tsx
+++ b/src/editor/components/buttons/copy/CopyButton.tsx
@@ -27,6 +27,7 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
         copyButtonType,
         copyButtonString,
         copyButtonStringCopied,
+        copyButtonUseTextarea,
         useDecodeURI,
         code,
         textColor,
@@ -39,15 +40,17 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
     const { Component } =
         copyButtonTypes?.[copyButtonType as keyof typeof copyButtonTypes] ??
         copyButtonTypes.heroicons;
+    const codeToCopy = stripAnsi(
+        useDecodeURI ? encodeURIComponent(code ?? '') : (code ?? ''),
+    );
+    console.log('codeToCopy', codeToCopy);
     return (
         <span
             // Using a span to prevent aggressive button styling from themes
             role="button"
             tabIndex={0}
             data-encoded={useDecodeURI ? true : undefined}
-            data-code={stripAnsi(
-                useDecodeURI ? encodeURIComponent(code ?? '') : code ?? '',
-            )}
+            data-code={copyButtonUseTextarea ? undefined : codeToCopy}
             style={{
                 color: color ?? 'inherit',
                 display: 'none',
@@ -56,13 +59,22 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
             aria-label={copyButtonString ?? __('Copy', 'code-block-pro')}
             data-copied-text={
                 hasTextButton
-                    ? copyButtonStringCopied ?? __('Copied!', 'code-block-pro')
+                    ? (copyButtonStringCopied ??
+                      __('Copied!', 'code-block-pro'))
                     : undefined
             }
             data-has-text-button={hasTextButton ? copyButtonType : undefined}
             data-inside-header-type={hasTextButton ? headerType : undefined}
             aria-live={hasTextButton ? 'polite' : undefined}
             className="code-block-pro-copy-button">
+            {copyButtonUseTextarea ? (
+                <textarea
+                    className="code-block-pro-copy-button-textarea"
+                    aria-hidden="true"
+                    readOnly>
+                    {codeToCopy}
+                </textarea>
+            ) : null}
             <Component text={copyButtonString} />
         </span>
     );

--- a/src/editor/components/buttons/sidebar/CopyBtnSettings.tsx
+++ b/src/editor/components/buttons/sidebar/CopyBtnSettings.tsx
@@ -27,7 +27,7 @@ export const CopyBtnSettings = ({
                 }}
             />
             {attributes.copyButton && (
-                <div className="flex gap-2 -mt-3">
+                <div className="flex gap-2">
                     {Object.entries(copyButtonTypes).map(([slug, data]) => {
                         const { Component } = data;
                         const {
@@ -94,6 +94,18 @@ export const CopyBtnSettings = ({
                             )}
                         />
                     )}
+                    <CheckboxControl
+                        label={__('Use Textarea', 'code-block-pro')}
+                        help={__(
+                            'Use a <textarea> to to store the code, otherwise a `data-code` attribute',
+                            'code-block-pro',
+                        )}
+                        checked={attributes.copyButtonUseTextarea}
+                        onChange={(copyButtonUseTextarea) => {
+                            setAttributes({ copyButtonUseTextarea });
+                            updateThemeHistory({ copyButtonUseTextarea });
+                        }}
+                    />
                 </div>
             )}
         </BaseControl>

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -18,8 +18,7 @@ const handleCopyButton = () => {
             if (type === 'keydown' && !['Enter', ' '].includes(key)) return;
             event.preventDefault();
             const t = b?.querySelector('textarea');
-            const source = t ? t?.value : b?.dataset;
-            console.log(source);
+            const source = t ? t?.value : b?.dataset?.code;
             const code = b?.dataset?.encoded
                 ? decodeURIComponent(decodeURIComponent(source))
                 : source;

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -13,14 +13,16 @@ const handleCopyButton = () => {
         // Setting it to block here lets users deactivate the plugin safely
         button.style.display = 'block';
         const handler = (event) => {
-            const { type, key, target } = event;
+            const { type, key, currentTarget: b } = event;
             // if keydown event, make sure it's enter or space
             if (type === 'keydown' && !['Enter', ' '].includes(key)) return;
             event.preventDefault();
-            const b = target?.closest('span[data-code]');
+            const t = b?.querySelector('textarea');
+            const source = t ? t?.value : b?.dataset;
+            console.log(source);
             const code = b?.dataset?.encoded
-                ? decodeURIComponent(decodeURIComponent(b?.dataset?.code))
-                : b?.dataset?.code;
+                ? decodeURIComponent(decodeURIComponent(source))
+                : source;
             const content = window.cbpCopyOverride?.(code, button) ?? code;
             copy(content ?? '', {
                 format: 'text/plain',

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -22,7 +22,7 @@
     padding: 16px;
     padding-right: 0;
     font-family: inherit;
-    @apply overflow-auto text-inherit text-left m-0 whitespace-pre bg-none border-none border-0 rounded-none shadow-none;
+    @apply overflow-auto text-inherit text-left m-0 whitespace-pre bg-none border-none border-0 rounded-none shadow-none outline-none focus-visible:outline-inherit;
 }
 .wp-block-kevinbatdorf-code-block-pro.padding-disabled:not(
         .code-block-pro-editor

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -164,8 +164,9 @@
 .code-block-pro-copy-button {
     border: 0;
     padding: 6px;
-    @apply absolute top-0 right-0 left-auto border-none border-0 cursor-pointer opacity-10 focus:opacity-40 transition-opacity duration-200 ease-in-out leading-none z-10;
+    @apply absolute top-0 right-0 left-auto border-none border-0 cursor-pointer opacity-10 focus:opacity-40 transition-opacity duration-200 ease-in-out leading-none z-10 outline-none focus-visible:outline-inherit;
 }
+
 .code-block-pro-copy-button:not([data-has-text-button]) {
     background: none;
     @apply bg-transparent;

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -170,6 +170,10 @@
     background: none;
     @apply bg-transparent;
 }
+.code-block-pro-copy-button-textarea {
+    clip: rect(0, 0, 0, 0);
+    @apply absolute top-0 left-0 w-px h-px opacity-0 pointer-events-none -m-1 overflow-hidden resize-none border-0 shadow-none bg-transparent text-transparent whitespace-nowrap;
+}
 .wp-block-kevinbatdorf-code-block-pro.padding-disabled
     .code-block-pro-copy-button {
     padding: 0;

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -171,7 +171,8 @@
     background: none;
     @apply bg-transparent;
 }
-.code-block-pro-copy-button-textarea {
+/* Keep this selector aggressively specific */
+body .wp-block-kevinbatdorf-code-block-pro:not(#x) .code-block-pro-copy-button-textarea {
     clip: rect(0, 0, 0, 0);
     @apply absolute top-0 left-0 w-px h-px opacity-0 pointer-events-none -m-1 overflow-hidden resize-none border-0 shadow-none bg-transparent text-transparent whitespace-nowrap;
 }

--- a/src/hooks/useDefaults.ts
+++ b/src/hooks/useDefaults.ts
@@ -45,6 +45,7 @@ export const useDefaults = ({
         previousCopyButtonType,
         previousCopyButtonString,
         previousCopyButtonStringCopied,
+        previousCopyButtonUseTextarea,
         previousTabSize,
         previousUseTabs,
         previousSeeMoreType,
@@ -84,6 +85,11 @@ export const useDefaults = ({
         const cpyP = previousCopyButtonStringCopied;
         setAttributes({ copyButtonStringCopied: cpyP });
     }, [previousCopyButtonStringCopied, copyButtonStringCopied, setAttributes]);
+
+    useEffect(() => {
+        if (once.current) return;
+        setAttributes({ copyButtonUseTextarea: previousCopyButtonUseTextarea });
+    }, [previousCopyButtonUseTextarea, setAttributes]);
 
     useEffect(() => {
         if (once.current) return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,6 +65,7 @@ registerBlockType<Attributes>(blockConfig.name, {
             type: 'string',
             default: __('Copied!', 'code-block-pro'),
         },
+        copyButtonUseTextarea: { type: 'boolean', default: false },
         useDecodeURI: { type: 'boolean', default: false },
         useEscapeShortCodes: { type: 'boolean', default: false },
         tabSize: { type: 'number', default: 2 },

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -20,6 +20,7 @@ type ThemeType = {
     previousCopyButtonType: string;
     previousCopyButtonString?: string;
     previousCopyButtonStringCopied?: string;
+    previousCopyButtonUseTextarea?: boolean;
     previousTabSize: number;
     previousUseTabs?: boolean;
     // previousEnableMaxHeight?: boolean;
@@ -53,6 +54,7 @@ const defaultSettings = {
     previousCopyButtonType: 'heroicons',
     previousCopyButtonString: __('Copy', 'code-block-pro'),
     previusCopyButtonStringCopied: __('Copied', 'code-block-pro'),
+    previousCopyButtonUseTextarea: true,
     previousTabSize: 2,
     previousUseTabs: false,
     // TODO: maybe impliment these with an extra UI to make them optional

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type Attributes = {
     copyButtonType: string;
     copyButtonString: string;
     copyButtonStringCopied: string;
+    copyButtonUseTextarea: boolean;
     useDecodeURI: boolean;
     useEscapeShortCodes: boolean;
     tabSize: number;


### PR DESCRIPTION
This fixes an issue when an html dom parser is used to minify or process the code on the server. It strips out the new lines. 

If you don't want this for some reason (an aggressive theme style maybe), then you'll have to disable it under Buttons

closes https://github.com/KevinBatdorf/code-block-pro/issues/345
closes https://github.com/KevinBatdorf/code-block-pro/issues/249
closes https://github.com/KevinBatdorf/code-block-pro/issues/300

(sorry for the delay)