### PR TITLE
Release 1.27.2

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -8,7 +8,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.27.1
+ * Version:           1.27.2
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82, dcooney, a169kai
 Tags:              block, code, syntax, highlighter, php
 Tested up to:      6.8
-Stable tag:        1.27.1
+Stable tag:        1.27.2
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -313,8 +313,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
-- Now uses textarea for code copy storing (can revert this under button settings)
-- Removed the WP outline style when clicking the copy button (now only when tab focused)
+= 1.27.2 - 2025-05-15 =
+- Refactors the copy button to use a textarea for copying
+- Removed the WP outline style on the copy button and pre (now only when tab focused)
 
 = 1.27.1 - 2025-05-15 =
 - Now scrolls back into view after a max height collapse


### PR DESCRIPTION
- Refactors the copy button to use a textarea for copying
- Removed the WP outline style on the copy button and pre (now only when tab focused)
