### PR TITLE
Prevent smart quotes etc from affecting copied code

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -8,7 +8,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.27.2
+ * Version:           1.27.3
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82, dcooney, a169kai
 Tags:              block, code, syntax, highlighter, php
 Tested up to:      6.8
-Stable tag:        1.27.2
+Stable tag:        1.27.3
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -312,6 +312,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 5. ANSI support for rendering control sequences
 
 == Changelog ==
+
+= 1.27.3 - 2025-05-15 =
+- Prevents smart quotes, typographic dashes, and other non-ASCII characters from affecting copied code snippets.
 
 = 1.27.2 - 2025-05-15 =
 - Refactors the copy button to use a textarea for copying

--- a/src/editor/components/buttons/copy/CopyButton.tsx
+++ b/src/editor/components/buttons/copy/CopyButton.tsx
@@ -70,9 +70,9 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
                 <textarea
                     className="code-block-pro-copy-button-textarea"
                     aria-hidden="true"
-                    readOnly>
-                    {codeToCopy}
-                </textarea>
+                    readOnly
+                    value={codeToCopy}
+                />
             ) : null}
             <Component text={copyButtonString} />
         </span>

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -2,6 +2,17 @@ import copy from 'copy-to-clipboard';
 
 const containerClass = '.wp-block-kevinbatdorf-code-block-pro';
 
+const sanitize = (str) =>
+    str
+        .replace(/[\u2018\u2019]/g, "'") // single quotes
+        .replace(/[\u201C\u201D]/g, '"') // double quotes
+        .replace(/[\u2013\u2014]/g, '-') // en/em dash
+        .replace(/\u2026/g, '...') // ellipsis
+        .replace(/[\u2039\u203A\u00AB\u00BB]/g, (c) =>
+            c === '‹' || c === '«' ? '<' : '>',
+        )
+        .replace(/\u00A0/g, ' '); // non-breaking space
+
 const handleCopyButton = () => {
     const buttons = Array.from(
         document.querySelectorAll(
@@ -22,7 +33,9 @@ const handleCopyButton = () => {
             const code = b?.dataset?.encoded
                 ? decodeURIComponent(decodeURIComponent(source))
                 : source;
-            const content = window.cbpCopyOverride?.(code, button) ?? code;
+            const content = sanitize(
+                window.cbpCopyOverride?.(code, button) ?? code,
+            );
             copy(content ?? '', {
                 format: 'text/plain',
                 onCopy: (code) => {


### PR DESCRIPTION
Sanitizes smart quotes and other non-ASCII chars from the copy button

Closes https://github.com/KevinBatdorf/code-block-pro/issues/367