### PR TITLE
Prevent wp_texturize from changing copy code

### DIFF
--- a/cypress/e2e/extra-settings.cy.js
+++ b/cypress/e2e/extra-settings.cy.js
@@ -31,13 +31,13 @@ context('Extra Settings', () => {
             codeOutput: '<script><</script>',
         });
 
-        cy.findBlock('code-block-pro', 'pre')
+        cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('not.contain', encodeURI('<'));
 
         cy.previewCurrentPage();
 
-        cy.get('.wp-block-kevinbatdorf-code-block-pro pre')
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .should('contain', '<script><</script>');
     });
@@ -49,13 +49,13 @@ context('Extra Settings', () => {
 
         cy.addCode('<script>&lt;</script>');
 
-        cy.findBlock('code-block-pro', 'pre')
+        cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('contain', '>lt</span>'); // formatted with highlighter
 
         cy.previewCurrentPage();
 
-        cy.get('.wp-block-kevinbatdorf-code-block-pro pre')
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .should('contain', '<script>&lt;</script>');
     });
@@ -68,12 +68,12 @@ context('Extra Settings', () => {
 
         cy.setLanguage('plaintext');
         cy.addCode('[embed]foo[/embed]');
-        cy.findBlock('code-block-pro', 'pre')
+        cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('contain', '[embed]foo[/embed]'); // Doesn't render
 
         cy.previewCurrentPage();
-        cy.get('.wp-block-kevinbatdorf-code-block-pro pre')
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .invoke('html')
             .should('contain', '<a href="http://foo">foo</a>'); // Renders
@@ -82,12 +82,12 @@ context('Extra Settings', () => {
         cy.focusBlock('code-block-pro');
         cy.openSideBarPanel('Extra Settings');
         cy.get('[data-cy="use-escape-shortcodes"]').check();
-        cy.findBlock('code-block-pro', 'pre')
+        cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('contain', '[embed]foo[/embed]'); // Doesn't render
 
         cy.previewCurrentPage();
-        cy.get('.wp-block-kevinbatdorf-code-block-pro pre')
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .invoke('html')
             .should('contain', '[embed]foo[/embed]'); // Doesn't render

--- a/cypress/e2e/height.cy.js
+++ b/cypress/e2e/height.cy.js
@@ -71,13 +71,13 @@ context('Max Height', () => {
 
         cy.previewCurrentPage();
 
-        cy.contains('foo = "5"').should('not.be.visible');
+        cy.get('.line').contains('foo = "5"').should('not.be.visible');
 
         cy.get('.cbp-see-more-simple-btn')
             .should('have.attr', 'aria-expanded', 'false')
             .click();
 
-        cy.contains('foo = "5"').should('be.visible');
+        cy.get('.line').contains('foo = "5"').should('be.visible');
 
         cy.get('.cbp-see-more-simple-btn').should('not.exist');
     });
@@ -123,7 +123,7 @@ context('Max Height', () => {
 
         cy.previewCurrentPage();
 
-        cy.contains('foo = "5"').should('not.be.visible');
+        cy.get('.line').contains('foo = "5"').should('not.be.visible');
 
         cy.get('.cbp-see-more-simple-btn')
             .should('exist')
@@ -136,7 +136,7 @@ context('Max Height', () => {
             'true',
         );
 
-        cy.contains('foo = "5"').should('be.visible');
+        cy.get('.line').contains('foo = "5"').should('be.visible');
 
         cy.get('.cbp-see-more-simple-btn').should(
             'have.text',
@@ -188,9 +188,9 @@ context('Max Height', () => {
 
         cy.previewCurrentPage();
 
-        cy.contains('foo = "5"').should('not.be.visible');
+        cy.get('.line').contains('foo = "5"').should('not.be.visible');
         cy.get('.cbp-see-more-simple-btn').click();
-        cy.contains('foo = "5"').should('be.visible');
+        cy.get('.line').contains('foo = "5"').should('be.visible');
         cy.get('.cbp-see-more-simple-btn').should('not.exist');
 
         cy.go('back');
@@ -208,7 +208,7 @@ context('Max Height', () => {
 
         cy.previewCurrentPage();
 
-        cy.contains('foo = "5"').should('not.be.visible');
+        cy.get('.line').contains('foo = "5"').should('not.be.visible');
         cy.get('.cbp-see-more-simple-btn').should('not.exist');
     });
 

--- a/cypress/e2e/misc.cy.js
+++ b/cypress/e2e/misc.cy.js
@@ -23,7 +23,7 @@ context('Miscellaneous', () => {
     it('Persists settings', () => {
         cy.addCode('const foo = "bar";');
         cy.setTheme('dracula');
-        cy.findBlock('code-block-pro', 'pre')
+        cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('contain', '<span style="color: #FF79C6">const</span>');
 
@@ -35,7 +35,7 @@ context('Miscellaneous', () => {
 
         // confirm theme is persisted
         cy.addCode('const foo = "bar";');
-        cy.findBlock('code-block-pro', 'pre')
+        cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('contain', '<span style="color: #FF79C6">const</span>');
     });

--- a/cypress/e2e/padding.cy.js
+++ b/cypress/e2e/padding.cy.js
@@ -26,7 +26,7 @@ afterEach(() => {
 });
 context('Line numbers', () => {
     it('Line numbers disabled, padding enabled', () => {
-        cy.findBlock('code-block-pro', 'pre').should(
+        cy.findBlock('code-block-pro', '> div > div > pre').should(
             'have.css',
             'padding',
             '16px 0px 16px 16px',
@@ -39,13 +39,13 @@ context('Line numbers', () => {
         cy.addCode('line 1\nline 2\nline 3');
         cy.previewCurrentPage();
 
-        cy.get('.wp-block-kevinbatdorf-code-block-pro pre')
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .should('have.css', 'padding', '16px 0px 16px 16px');
     });
 
     it('Line numbers disabled, padding disabled', () => {
-        cy.findBlock('code-block-pro', 'pre').should(
+        cy.findBlock('code-block-pro', '> div > div > pre').should(
             'have.css',
             'padding',
             '16px 0px 16px 16px',
@@ -60,7 +60,7 @@ context('Line numbers', () => {
         cy.get('[data-cy="disable-padding"').check();
         cy.get('[data-cy="disable-padding"').should('be.checked');
 
-        cy.findBlock('code-block-pro', 'pre').should(
+        cy.findBlock('code-block-pro', '> div > div > pre').should(
             'have.css',
             'padding',
             '0px',
@@ -72,7 +72,7 @@ context('Line numbers', () => {
 
         cy.previewCurrentPage();
 
-        cy.get('.wp-block-kevinbatdorf-code-block-pro pre')
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .should('have.css', 'padding', '0px');
     });
@@ -93,7 +93,7 @@ context('Line numbers', () => {
 
         cy.previewCurrentPage();
 
-        cy.get('.wp-block-kevinbatdorf-code-block-pro pre')
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .should('have.css', 'padding', '16px 0px 16px 16px');
     });
@@ -130,7 +130,7 @@ context('Line numbers', () => {
 
         cy.previewCurrentPage();
 
-        cy.get('.wp-block-kevinbatdorf-code-block-pro pre')
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .should('have.css', 'padding', '0px');
     });

--- a/cypress/e2e/themes.cy.js
+++ b/cypress/e2e/themes.cy.js
@@ -26,17 +26,17 @@ context('Theme checks', () => {
         // Nord is the default
         cy.addCode('const foo = "bar";');
         cy.setTheme('nord');
-        cy.findBlock('code-block-pro', 'pre')
+        cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('contain', '<span style="color: #81A1C1">const</span>');
 
         cy.setTheme('dracula');
-        cy.findBlock('code-block-pro', 'pre')
+        cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('contain', '<span style="color: #FF79C6">const</span>');
 
         cy.setTheme('rose-pine-dawn');
-        cy.findBlock('code-block-pro', 'pre')
+        cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('contain', '<span style="color: #286983">const</span>');
 

--- a/php/compatibility.php
+++ b/php/compatibility.php
@@ -11,23 +11,11 @@ defined('ABSPATH') or die;
 if (!class_exists('Prismatic')) {
     class Prismatic
     {
-        public static function options_general()
-        {
-        }
-        public static function options_advanced()
-        {
-        }
-        public static function options_prism()
-        {
-        }
-        public static function options_highlight()
-        {
-        }
-        public static function options_plain()
-        {
-        }
+        public static function options_general() {}
+        public static function options_advanced() {}
+        public static function options_prism() {}
+        public static function options_highlight() {}
+        public static function options_plain() {}
     }
-    function prismatic()
-    {
-    }
+    function prismatic() {}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -313,6 +313,8 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Prevents wp_texturize from affecting copied code snippets. You will see a block update for this change as I had to wrap the code in a pre tag.
+
 = 1.27.3 - 2025-05-15 =
 - Prevents smart quotes, typographic dashes, and other non-ASCII characters from affecting copied code snippets.
 

--- a/src/editor/components/buttons/copy/CopyButton.tsx
+++ b/src/editor/components/buttons/copy/CopyButton.tsx
@@ -67,12 +67,17 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
             aria-live={hasTextButton ? 'polite' : undefined}
             className="code-block-pro-copy-button">
             {copyButtonUseTextarea ? (
-                <textarea
-                    className="code-block-pro-copy-button-textarea"
-                    aria-hidden="true"
-                    readOnly
-                    value={codeToCopy}
-                />
+                <pre
+                    className="code-block-pro-copy-button-pre"
+                    aria-hidden="true">
+                    <textarea
+                        className="code-block-pro-copy-button-textarea"
+                        tabIndex={-1}
+                        aria-hidden="true"
+                        readOnly
+                        value={codeToCopy}
+                    />
+                </pre>
             ) : null}
             <Component text={copyButtonString} />
         </span>

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -172,6 +172,7 @@
     @apply bg-transparent;
 }
 /* Keep this selector aggressively specific */
+body .wp-block-kevinbatdorf-code-block-pro:not(#x) .code-block-pro-copy-button-pre,
 body .wp-block-kevinbatdorf-code-block-pro:not(#x) .code-block-pro-copy-button-textarea {
     clip: rect(0, 0, 0, 0);
     @apply absolute top-0 left-0 w-px h-px opacity-0 pointer-events-none -m-1 overflow-hidden resize-none border-0 shadow-none bg-transparent text-transparent whitespace-nowrap;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,9 @@ import { transformToCBP, transformFromCBP } from './editor/transforms';
 import { BlockOutput } from './front/BlockOutput';
 import { blockIcon } from './icons';
 import { Attributes } from './types';
+import { handleValidationErrors } from './util/errors';
+
+handleValidationErrors();
 
 registerBlockType<Attributes>(blockConfig.name, {
     ...blockConfig,

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,0 +1,41 @@
+import { subscribe } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+export const debounce = <T extends (...args: unknown[]) => void>(
+    fn: T,
+    delay: number,
+) => {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    return (...args: Parameters<T>) => {
+        if (timeout) clearTimeout(timeout);
+        timeout = setTimeout(() => fn(...args), delay);
+    };
+};
+
+export const handleValidationErrors = () => {
+    const debouncedUnsub = debounce(() => unsub(), 5000);
+    const unsub = subscribe(() => {
+        const editor = document.querySelector(
+            '#editor, iframe[name="editor-canvas"]',
+        );
+        const blockError = editor?.querySelector(
+            '.wp-block-kevinbatdorf-code-block-pro .block-editor-warning',
+        );
+        if (blockError) unsub();
+        const message = blockError?.querySelector(
+            '.block-editor-warning__message',
+        );
+        if (!message) return;
+        message.textContent = __(
+            'This block has been updated. Press update to refresh.',
+            'code-block-pro',
+        );
+        const button = blockError?.querySelector(
+            '.block-editor-warning__action button',
+        );
+        if (!button) return;
+        button.textContent = __('Update', 'code-block-pro');
+
+        debouncedUnsub();
+    });
+};


### PR DESCRIPTION
This wraps the copy code in a `pre` tag to prevent wordpress from running wptexturize on the code.


See here: https://github.com/KevinBatdorf/code-block-pro/issues/367#issuecomment-2984082251