### PR TITLE
Handle shortcodes in copy button

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -8,7 +8,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.27.4
+ * Version:           1.27.5
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/cypress/e2e/buttons.cy.js
+++ b/cypress/e2e/buttons.cy.js
@@ -158,6 +158,22 @@ context('Copy button', () => {
             .should('contain', '<span class="cbp-btn-text">it worked!');
     });
 
+    it('Escapes WordPress shortcodes', () => {
+        const text = '[embed]foo[/embed]';
+        cy.setLanguage('plaintext');
+        cy.addCode(text);
+
+        cy.previewCurrentPage();
+        cy.get('.wp-block-kevinbatdorf-code-block-pro [aria-label="Copy"]')
+            .should('exist')
+            .realClick();
+        cy.window().then((win) => {
+            win.navigator.clipboard.readText().then((clipText) => {
+                expect(clipText).to.equal(text);
+            });
+        });
+    });
+
     // Doesn't seem to work 🤷
     // it.only('Copies code on keypress', () => {
     //     const text = 'const foo = "bar";';

--- a/cypress/e2e/extra-settings.cy.js
+++ b/cypress/e2e/extra-settings.cy.js
@@ -62,9 +62,6 @@ context('Extra Settings', () => {
 
     it('Escapes WordPress shortcodes', () => {
         cy.openSideBarPanel('Extra Settings');
-        cy.get('[data-cy="use-escape-shortcodes"]')
-            .should('exist')
-            .should('not.be.checked');
 
         cy.setLanguage('plaintext');
         cy.addCode('[embed]foo[/embed]');
@@ -76,12 +73,12 @@ context('Extra Settings', () => {
         cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .invoke('html')
-            .should('contain', '<a href="http://foo">foo</a>'); // Renders
+            .should('contain', '[embed]foo[/embed]'); // Doesn't render
 
         cy.go('back');
         cy.focusBlock('code-block-pro');
         cy.openSideBarPanel('Extra Settings');
-        cy.get('[data-cy="use-escape-shortcodes"]').check();
+        cy.get('[data-cy="use-escape-shortcodes"]').uncheck();
         cy.findBlock('code-block-pro', '> div > div > pre')
             .invoke('html')
             .should('contain', '[embed]foo[/embed]'); // Doesn't render
@@ -90,6 +87,6 @@ context('Extra Settings', () => {
         cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
             .should('exist')
             .invoke('html')
-            .should('contain', '[embed]foo[/embed]'); // Doesn't render
+            .should('contain', '<a href="http://foo">foo</a>'); // Renders
     });
 });

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82, dcooney, a169kai
 Tags:              block, code, syntax, highlighter, php
 Tested up to:      6.8
-Stable tag:        1.27.4
+Stable tag:        1.27.5
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -313,6 +313,7 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+= 1.27.5 - 2025-06-21 =
 - Changes the default value for escaping wp shortcodes to true. Can't see why anyone would want this any other way by default.
 - Prevents shortcodes from rendering in the copy button
 

--- a/readme.txt
+++ b/readme.txt
@@ -313,6 +313,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 
 == Changelog ==
 
+- Changes the default value for escaping wp shortcodes to true. Can't see why anyone would want this any other way by default.
+- Prevents shortcodes from rendering in the copy button
+
 = 1.27.4 - 2025-06-20 =
 - Prevents wp_texturize from affecting copied code snippets. You will see a block update for this change as I had to wrap the code in a pre tag.
 

--- a/src/editor/components/buttons/copy/CopyButton.tsx
+++ b/src/editor/components/buttons/copy/CopyButton.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import stripAnsi from 'strip-ansi';
 import { Attributes } from '../../../../types';
+import { escapeShortcodes } from '../../../../util/code';
 import { Clipboard } from './Clipboard';
 import { TextSimple } from './TextSimple';
 import { TwoSquares } from './TwoSquares';
@@ -33,6 +34,7 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
         textColor,
         bgColor: b,
         headerType,
+        useEscapeShortCodes,
     } = attributes;
     const hasTextButton = copyButtonType === 'textSimple';
     const color = hasTextButton ? b : textColor;
@@ -49,7 +51,13 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
             role="button"
             tabIndex={0}
             data-encoded={useDecodeURI ? true : undefined}
-            data-code={copyButtonUseTextarea ? undefined : codeToCopy}
+            data-code={
+                copyButtonUseTextarea
+                    ? undefined
+                    : useEscapeShortCodes
+                      ? escapeShortcodes(codeToCopy)
+                      : codeToCopy
+            }
             style={{
                 color: color ?? 'inherit',
                 display: 'none',
@@ -75,7 +83,11 @@ export const CopyButton = ({ attributes }: { attributes: Attributes }) => {
                         tabIndex={-1}
                         aria-hidden="true"
                         readOnly
-                        value={codeToCopy}
+                        value={
+                            useEscapeShortCodes
+                                ? escapeShortcodes(codeToCopy)
+                                : codeToCopy
+                        }
                     />
                 </pre>
             ) : null}

--- a/src/hooks/useDefaults.ts
+++ b/src/hooks/useDefaults.ts
@@ -53,6 +53,7 @@ export const useDefaults = ({
         previousSeeMoreTransition,
         previousSeeMoreCollapse,
         previousSeeMoreCollapseString,
+        previousUseEscapeShortCodes,
     } = useThemeStore();
     const ready = useThemeStoreReady();
     const once = useRef(false);

--- a/src/hooks/useDefaults.ts
+++ b/src/hooks/useDefaults.ts
@@ -53,7 +53,6 @@ export const useDefaults = ({
         previousSeeMoreTransition,
         previousSeeMoreCollapse,
         previousSeeMoreCollapseString,
-        previousUseEscapeShortCodes,
     } = useThemeStore();
     const ready = useThemeStoreReady();
     const once = useRef(false);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,7 +70,7 @@ registerBlockType<Attributes>(blockConfig.name, {
         },
         copyButtonUseTextarea: { type: 'boolean', default: false },
         useDecodeURI: { type: 'boolean', default: false },
-        useEscapeShortCodes: { type: 'boolean', default: false },
+        useEscapeShortCodes: { type: 'boolean', default: true },
         tabSize: { type: 'number', default: 2 },
         useTabs: { type: 'boolean' },
     },


### PR DESCRIPTION
Fixes an issue where shortcodes are rendering in the copy button

closes https://github.com/KevinBatdorf/code-block-pro/issues/379