### PR TITLE
Properly escape shortcodes with attributes

### DIFF
--- a/code-block-pro.php
+++ b/code-block-pro.php
@@ -8,7 +8,7 @@
  * Author URI:        https://code-block-pro.com/?utm_campaign=plugin&utm_source=author-uri
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.27.5
+ * Version:           1.27.6
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       code-block-pro

--- a/cypress/e2e/buttons.cy.js
+++ b/cypress/e2e/buttons.cy.js
@@ -174,6 +174,37 @@ context('Copy button', () => {
         });
     });
 
+    it('Copy button copies audio and video shortcodes with attributes', () => {
+        const text = '[audio src="fake.mp3"]\n[video src="fake.mp4"]';
+        cy.setLanguage('plaintext');
+        cy.addCode(text);
+
+        cy.previewCurrentPage();
+        cy.get('.wp-block-kevinbatdorf-code-block-pro [aria-label="Copy"]')
+            .should('exist')
+            .realClick();
+        cy.window().then((win) => {
+            win.navigator.clipboard.readText().then((clipText) => {
+                expect(clipText).to.equal(text);
+            });
+        });
+
+        cy.go('back');
+        cy.focusBlock('code-block-pro');
+        cy.openSideBarPanel('Extra Settings');
+        cy.get('[data-cy="use-escape-shortcodes"]').uncheck();
+
+        cy.previewCurrentPage();
+        cy.get('.wp-block-kevinbatdorf-code-block-pro [aria-label="Copy"]')
+            .should('exist')
+            .realClick();
+        cy.window().then((win) => {
+            win.navigator.clipboard.readText().then((clipText) => {
+                expect(clipText).to.not.equal(text);
+            });
+        });
+    });
+
     // Doesn't seem to work 🤷
     // it.only('Copies code on keypress', () => {
     //     const text = 'const foo = "bar";';

--- a/cypress/e2e/extra-settings.cy.js
+++ b/cypress/e2e/extra-settings.cy.js
@@ -89,4 +89,40 @@ context('Extra Settings', () => {
             .invoke('html')
             .should('contain', '<a href="http://foo">foo</a>'); // Renders
     });
+
+    it('Escapes WordPress audio and video shortcodes with attributes', () => {
+        cy.openSideBarPanel('Extra Settings');
+
+        cy.setLanguage('plaintext');
+        cy.addCode('[audio src="fake.mp3"]\n[video src="fake.mp4"]');
+        cy.findBlock('code-block-pro', '> div > div > pre')
+            .invoke('html')
+            .should('contain', '[audio src="fake.mp3"]')
+            .and('contain', '[video src="fake.mp4"]');
+
+        cy.previewCurrentPage();
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
+            .should('exist')
+            .invoke('html')
+            .should('contain', '[audio src="fake.mp3"]')
+            .and('contain', '[video src="fake.mp4"]');
+
+        cy.go('back');
+        cy.focusBlock('code-block-pro');
+        cy.openSideBarPanel('Extra Settings');
+        cy.get('[data-cy="use-escape-shortcodes"]').uncheck();
+        cy.findBlock('code-block-pro', '> div > div > pre')
+            .invoke('html')
+            .should('contain', '[audio src="fake.mp3"]')
+            .and('contain', '[video src="fake.mp4"]')
+            .and('not.contain', 'wp-embedded-audio')
+            .and('not.contain', 'wp-embedded-video');
+
+        cy.previewCurrentPage();
+        cy.get('.wp-block-kevinbatdorf-code-block-pro pre.shiki')
+            .should('exist')
+            .invoke('html')
+            .should('contain', 'wp-embedded-audio')
+            .and('contain', 'wp-embedded-video');
+    });
 });

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82, dcooney, a169kai
 Tags:              block, code, syntax, highlighter, php
 Tested up to:      6.8
-Stable tag:        1.27.5
+Stable tag:        1.27.6
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -312,6 +312,9 @@ Themes are rendered inside the editor as you type or make changes, so the code b
 5. ANSI support for rendering control sequences
 
 == Changelog ==
+
+= 1.27.6 - 2025-06-29 =
+- Fixes a bug where shortcodes with attributes would not be properly escaped.
 
 = 1.27.5 - 2025-06-21 =
 - Changes the default value for escaping wp shortcodes to true. Can't see why anyone would want this any other way by default.

--- a/src/util/code.ts
+++ b/src/util/code.ts
@@ -29,7 +29,6 @@ export const decode = (code: string, { useDecodeURI }: Partial<Attributes>) => {
 };
 
 export const escapeShortcodes = (content: string) =>
-    // eslint-disable-next-line no-control-regex
-    content.replaceAll(/\[([^<>&/[\]\x00-\x20=]+)\]/g, (match) =>
+    content.replaceAll(/\[([^[\]]+)\]/g, (match) =>
         match.replace('[', '&#91;').replace(']', '&#93;'),
     );


### PR DESCRIPTION
Fixes a bug where shortcodes with attributes would still be rendering.

Reference: https://wordpress.org/support/topic/serious-some-codes-are-read-by-the-system-and-become-critical-errors