### PR TITLE
Ignore transitive deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
       directory: '/'
       schedule:
           interval: 'monthly'
+      ignore:
+          # Transitive deps pinned by @wordpress/scripts — can't bump independently
+          - dependency-name: 'lodash'
+          - dependency-name: 'lodash-es'
+          - dependency-name: 'axios'
+          - dependency-name: 'node-forge'
+          - dependency-name: 'basic-ftp'


### PR DESCRIPTION
These deps (lodash, axios, node-forge, basic-ftp, lodash-es) are pinned by `@wordpress/scripts` and can't be bumped independently. Dependabot keeps opening PRs we can't merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)