### PR TITLE
Add testing rules and walk-up blueprint discovery

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,48 @@
+---
+path: tests/**
+---
+
+# Playwright + WP Playground Testing Guidelines
+
+## Architecture
+
+- Each `*.spec.ts` file is its own Playwright project, CI matrix job, and WP Playground instance.
+- `playwright.config.ts` auto-discovers specs by finding `*.spec.ts` files and walking up from the spec's directory to find the closest `blueprint.json`. A shared blueprint in `tests/` serves all specs unless a subdirectory provides its own override.
+- Multiple specs sharing the same `blueprint.json` share a Playground instance. To isolate a test, give it its own directory with its own `blueprint.json`.
+- Each spec = one separate GitHub Actions runner = one fresh WP Playground instance. They do NOT share state across specs. Tests within the same spec DO share state.
+
+## Editor Canvas vs Page
+
+WordPress renders the block editor inside an iframe.
+
+- `editor.canvas` — use for anything inside the editor: blocks, text content, inline styles.
+- `page` — use for sidebar panels, toolbar buttons, settings controls.
+
+## Common Pitfalls
+
+- **Never use `page.goBack()`.** WP Playground crashes. Split into separate tests instead.
+- **No retries.** `retries: 0` in config. Retries mask real failures.
+- **State leaks between tests.** Tests in the same spec share a Playground. Theme, settings, and block defaults persist. Explicitly reset anything a previous test might have changed.
+- **Duplicate IDs.** Some WP components render both a visible element and a loading placeholder with the same ID. Use `button#code-block-pro-theme-nord` instead of `#code-block-pro-theme-nord`.
+- **Hidden copy-button pre.** The block has a hidden `<pre class="code-block-pro-copy-button-pre">` for clipboard. Use `pre:not(.code-block-pro-copy-button-pre)` when querying the visible code pre.
+
+## Assertions
+
+- Use `toBeInViewport()` not `toBeVisible()` for content hidden by `max-height` / `overflow: hidden`.
+- Use `expect.poll()` or `expect(...).toPass({ timeout })` for async operations instead of `waitForTimeout`.
+- Use `{ timeout: 10000 }` on `toHaveCSS` when checking dynamically applied styles.
+
+## Preview / Front-End Testing
+
+- `admin.createNewPost()` creates a post, not a page. Preview URL: `/?p=${postId}&preview=true`.
+- Save the draft and wait for the saved state before navigating to preview.
+- On the front end, use `page.locator('.wp-block-...')` — no `editor.canvas` needed.
+
+## Shared Helpers
+
+`tests/helpers.ts` has common utilities: `insertCodeBlock`, `addCode`, `getBlock`, `getCodePre`, `openPanel`, `setTheme`, `setLanguage`, `setHeader`, `setFooter`, `previewPage`, `setupCodeBlock`, etc.
+
+## Config
+
+- Use `fast-glob` not `node:fs` `globSync` — `@types/node` is pinned to v20 by `@wordpress/e2e-test-utils-playwright`.
+- Use `.filter((s): s is { ... } => s !== null)` instead of `.filter(Boolean)` for type narrowing.

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,9 @@ Cargo.lock
 tsconfig.tsbuildinfo
 test-results
 playwright-report
-.claude
+# Claude Code — commit rules and skills, ignore user-specific files
+.claude/*
+!.claude/rules/
+!.claude/skills/
+!.claude/settings.json
 .vscode

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,13 +7,24 @@ const BASE_PORT = 9400;
 const WP_VERSION = process.env.WP_VERSION || 'latest';
 const RUN_PROJECT = process.env.RUN_PROJECT;
 
-// Discover spec files that have a blueprint.json in the same directory
+// Find the closest blueprint.json by walking up from the spec's directory
+function findBlueprint(dir: string): string | null {
+	let current = dir;
+	while (current !== '.' && current !== '/') {
+		const bp = join(current, 'blueprint.json');
+		if (existsSync(bp)) return bp;
+		current = dirname(current);
+	}
+	return null;
+}
+
+// Discover spec files that have a blueprint.json in their directory or any ancestor
 const specs = fg
 	.sync('**/*.spec.ts', { ignore: ['node_modules/**'] })
 	.map((spec) => {
 		const dir = dirname(spec);
-		const blueprint = join(dir, 'blueprint.json');
-		if (!existsSync(blueprint)) return null;
+		const blueprint = findBlueprint(dir);
+		if (!blueprint) return null;
 		return {
 			name: basename(spec, '.spec.ts'),
 			dir,


### PR DESCRIPTION
## Summary
- `.claude/rules/testing.md` — Playwright + WP Playground testing guidelines, path-scoped to `tests/**`. Auto-loads when working on test files.
- `playwright.config.ts` — walks up directories to find the closest `blueprint.json` so specs can share a parent blueprint without duplicating the file.
- `.gitignore` — selectively tracks `.claude/rules/`, `skills/`, and `settings.json`, ignores user-specific files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)